### PR TITLE
Fixing the manpages

### DIFF
--- a/src/docsosf/man/man1/aclock.1
+++ b/src/docsosf/man/man1/aclock.1
@@ -14,37 +14,36 @@
 .\" 
 .\" $EndLog$
 .\"
-.\" This manpage source uses rsml coding. 
-.\"
-.so /usr/share/lib/tmac/sml
-.so /usr/share/lib/tmac/rsml
-.TH aclock 1dtk "" "" "" "DECtalk" ""
+.TH ACLOCK 1dtk "" "" "" "DECtalk" ""
 .SH NAME
-.PP
-\*Laclock\*O \- Talking clock
+aclock \- Talking clock
 .SH SYNOPSIS
 .PP
-.sS
-\*Laclock\*O \*O[\*L-h #\*O]
-.sE
+.B aclock
+.RB [ \-h ]
+.RI [ # ]
 .SH FLAGS
-.PP
-.VL 4m
-.LI "\*L-h\*O"
+.Tp
+.BR \-h
 Displays the command line parameter list
-.LE
 .SH PARAMETERS
-.PP
-.VL 4m
-.LI "\*L#\*O"
-.nf
+.TP
+.I #
 where \*L#\*O is the interval in minutes:
-5  - every five minutes
-15 - every fifteen minutes
-30 - on the hour and half hour
-60 - on the hour
-.fi
-.LE
+.RS
+.TP
+5
+every five minutes
+.TP
+15
+every fifteen minutes
+.TP
+30
+on the hour and half hour
+.TP
+60
+on the hour
+.RE
 .SH DESCRIPTION
 .PP
 aclock announces the time of the day using DECtalk Software.
@@ -53,6 +52,8 @@ aclock announces the time of the day using DECtalk Software.
 aclock 5  -  Announces time of the day every five minutes.
 .SH RELATED INFORMATION
 .PP
-\*Ldectalk\*O(1dtk), \*Laudiocontrol\*O(1mms), \*Lmmeserver\*O(1mms)
+.BR dectalk (1dtk),
+.BR audiocontrol (1mms),
+.BR mmeserver (1mms)
 .PP
 DECtalk Software Programmer's Guide

--- a/src/docsosf/man/man1/dectalk.1
+++ b/src/docsosf/man/man1/dectalk.1
@@ -14,109 +14,99 @@
 .\" 
 .\" $EndLog$
 .\"
-.\" This manpage source uses rsml coding. 
-.\"
-.so /usr/share/lib/tmac/sml
-.so /usr/share/lib/tmac/rsml
-.TH dectalk 1dtk "" "" "" "DECtalk" ""
+.TH DECTALK 1dtk "" "" "" "DECtalk" ""
 .SH NAME
-.PP
-\*Ldectalk\*O \- DECtalk Software  
+dectalk \- DECtalk Software  
 .SH DESCRIPTION
 .PP
-\*LDECtalk Software\*O is text-to-speech 
-software based on Force Computers' text-to-speech 
-synthesis technology.
+.B DECtalk software
+is text-to-speech software
+based on Force Computers' text-to-speech synthesis technology.
 .PP
-\*LDECtalk Software\*O allows applications to convert standard 
-ASCII text in any of several languages into highly intelligible and 
-natural sounding speech, playable through audio hardware on 
-Linux, Tru64 UNIX, and Windows systems.
+.B DECtalk software
+allows applications to convert standard ASCII text
+in any of several languages
+into highly intelligible and natural sounding speech,
+playable through audio hardware on Linux, Tru64 UNIX, and Windows systems.
 .PP
-For Linux, the software is offered in a unified Software Development
-Kit (SDK).  For Tru64 UNIX,
-the software is organized into two subsets - a Runtime kit and a 
-Development kit. The Runtime kit includes:
-.ML
-.LI
-\*Lspeak\*O - an application that allows a user to synthesize 
-a text file or text typed into a window. It provides control of 
-voice and speaking rate and its interface is consistent with the 
-Motif windowing environment.
-.LI
-\*Laclock\*O - an application that speaks clock time at set intervals
-.LI
-\*Lsay\*O - an application that allows a user to synthesize
-a text file to speech
-.LI
-\*Lwindict\*O - a Motif windows based user-dictionary compiler used to
-create customized pronunciation dictionaries
-.LE
+For Linux, the software is offered in a unified Software Development Kit (SDK).
+For Tru64 UNIX, the software is organized into two subsets -
+a Runtime kit and a Development kit.
+The Runtime kit includes:
+.TP
+.BR speak (1)
+an application that allows a user to synthesize 
+a text file or text typed into a window.
+It provides control of voice and speaking rate
+and its interface is consistent with the Motif windowing environment.
+.TP
+.BR aclock (1)
+an application that speaks clock time at set intervals
+.TP
+.BR say (1),
+an application that allows a user to synthesize a text file to speech
+.TP
+.BR windict (1)
+a Motif windows based user-dictionary compiler
+used to create customized pronunciation dictionaries
 .PP
 The Development kit includes:
-.ML
-.LI
-A DECtalk Software application programming interface (API) to allow
-any application to include text-to-speech synthesis, with functions
-that support a rich set of text-to-speech features (detailed below). 
-.LI
+.IP \(bu
+A DECtalk Software application programming interface (API)
+to allow any application to include text-to-speech synthesis,
+with functions that support a rich set of text-to-speech features
+(detailed below). 
+.IP \(bu
 C language sample code for the following applets:
-.LI
-\*Laclock\*O - an application that speaks clock time at set intervals
-.LI
-\*Lxmsay\*O - a Motif applet that allows a user to synthesize a text
-file to speech
-.LI
-\*Lsay\*O - a command line applet that allows a user to synthesize
-a text file to speech
-.LI
-\*Ldtmemory\*O - a facility that returns synthesized speech via in-memory buffers and
-writes it to a file
-.LE
+aclock,
+xmsay,
+say,
+and dtmemory.
 .PP
 DECtalk Software API functions support the following features:
-.ML
-.LI
-Text-to-speech synthesis in several languages (currently
-US English, UK English, Castialian Spanish, Latin American Spanish,
-German, and French)
-.LI
-Nine defined voice personalities (four female, four male, and one
-child)
-.LI
+.IP \(bu
+Text-to-speech synthesis in several languages
+(currently US English, UK English,
+Castialian Spanish, Latin American Spanish, German, and French)
+.IP \(bu
+Nine defined voice personalities
+(four female, four male, and one child)
+.IP \(bu
 Ability to say letters, words, or phrases
-.LI
+.IP \(bu
 Pause, continue, and stop speaking control
-.LI
+.IP \(bu
 Variable speaking rates from 75 to 600 words per minute
-.LI
+.IP \(bu
 Accurate letter-to-sound pronunciation rules
-.LI
+.IP \(bu
 Large internal (fixed) dictionaries
-.LI
+.IP \(bu
 Facilities for expanded developer-definable dictionaries
-.LI
+.IP \(bu
 Punctuation control for pauses, pitch, and stress
-.LI
+.IP \(bu
 Output stereo volume control
-.LI
+.IP \(bu
 Ability to say proper names
-.LI
+.IP \(bu
 User-defined pronunciation dictionary
-.LI
+.IP \(bu
 Ability to synthesize to a file
-.LI
+.IP \(bu
 Ability to synthesize to memory
-.LI
+.IP \(bu
 Ability to play wave audio files
-.LI
+.IP \(bu
 Ability to generate DTMF tones for dialing
-.LI
+.IP \(bu
 Ability to generate tones of a specified frequency and duration
-.LE
 .SH RELATED INFORMATION
 .PP
-\*Laclock\*O(1dtk), \*Lsay\*O(1dtk), \*Lspeak\*O(1dtk), \*Lwindict\*O(1dtk)
+.BR aclock (1dtk),
+.BR say (1dtk),
+.BR speak (1dtk),
+.BR windict (1dtk)
 .PP
 DECtalk Software Programmer's Guide
 .PP

--- a/src/docsosf/man/man1/emacspeak.1
+++ b/src/docsosf/man/man1/emacspeak.1
@@ -13,41 +13,47 @@
 .\" 
 .\" $EndLog$
 .\"
-.\" This manpage source uses rsml coding. 
-.\"
-.so /usr/share/lib/tmac/sml
-.so /usr/share/lib/tmac/rsml
-.TH emacspeak 1dtk "" "" "" "DECtalk" ""
+.TH EMACSPEAK 1dtk "" "" "" "DECtalk" ""
 .SH NAME
-.PP
-\*Lemacspeak\*O \- Speech-enables emacs
+emacspeak \- Speech-enables emacs
 .SH DESCRIPTION
 .PP
-\*Lemacspeak\*O is an emacs subsystem that provides speech feedback using
-synthesized speech.  The basic concepts used by Emacspeak are simple; all
-Emacs cursor movement commands as well as the various input-output functions
-are adapted to provide speech feedback.  Hence, a user can use Emacs as they
-normally would; emacspeak works behind the scenes to give audio feedback in
-addition to updating the screen.
+.B emacspeak
+is an emacs subsystem
+that provides speech feedback using synthesized speech.
+The basic concepts used by Emacspeak are simple;
+all Emacs cursor movement commands
+as well as the various input-output functions
+are adapted to provide speech feedback.
+Hence, a user can use Emacs as they normally would;
+emacspeak works behind the scenes to give audio feedback
+in addition to updating the screen.
 .SH ACCESSING EMACSPEAK
 .PP
-To access emacspeak under Tru64 UNIX, you must choose to install emacspeak
-during DECtalk Software runtime kit installation.
+To access emacspeak under Tru64 UNIX,
+you must choose to install emacspeak during DECtalk Software runtime kit installation.
 .PP
 All emacspeak files end up in the directory
-\*L/usr/opt/DTKRTnnn/emacspeak\*O, where nnn denotes the DECtalk Software
-version, at the end of installation.
+.BR /usr/opt/DTKRTnnn/emacspeak ,
+where nnn denotes the DECtalk Software version,
+at the end of installation.
 .PP
-To use emacspeak after runtime kit installation, change directory (\*Lcd\*O)
-over to \*L/usr/opt/DTKRTnnn/emacspeak/Macros\*O and type: \*Lmake help\*O.
+To use emacspeak after runtime kit installation,
+change directory (\fBcd\fP) over to
+.B /usr/opt/DTKRTnnn/emacspeak/Macros
+and type:
+.BR "make help" .
 Follow the instructions to complete installing emacspeak.
 .SH RELATED INFORMATION
 .PP
-\*Ldectalk\*O(1dtk)
+.BR dectalk (1dtk),
+.BR emacs (1),
 .PP
-\*Lemacspeak-README.txt\*O - In /usr/opt/DTKRTnnn/emacspeak/docs/ascii
+.B emacspeak-README.txt
+- In /usr/opt/DTKRTnnn/emacspeak/docs/ascii
 .PP
-\*Lemacspeak.ps\*O - In /usr/opt/DTKRTnnn/emacspeak/docs/postscript
+.B emacspeak.ps
+- In /usr/opt/DTKRTnnn/emacspeak/docs/postscript
 .PP
 DECtalk Software Programmer's Guide
 .PP

--- a/src/docsosf/man/man1/say.1
+++ b/src/docsosf/man/man1/say.1
@@ -14,52 +14,66 @@
 .\" 
 .\" $EndLog$
 .\"
-.\" This manpage source uses rsml coding. 
 .\"
-.so /usr/share/lib/tmac/sml
-.so /usr/share/lib/tmac/rsml
-.\"
-.TH say 1dtk "" "" "" "DECtalk" ""
+.TH SAY 1dtk "" "" "" "DECtalk" ""
 .SH NAME
-.PP
-\*Lsay\*O \- Shell command to speak text using DECtalk Software
+say \- Shell command to speak text using DECtalk Software
 .SH SYNOPSIS
 .PP
-.sS
-\*Lsay \*O\*L[-h] [-s #] [-r #] [-d #] [-e #] [-fi filename] [-fo <filename>] 
-    \*O\*L[-a "text"]\*O
-.sE    
+.B say
+.RB [ \-h ]
+[\fB\-r\fP \fI#\fP]
+[\fB\-r\fP \fI#\fP]
+[\fB\-d\fP \fI#\fP]
+[\fB\-e\fP \fB#\fI]
+[\fB\-fi\fP \fIfilename\fP]
+[\fB\-fo\fP \fIfilename\fP]
+[\fB\-a\fP \fItext\fP]
 .SH FLAGS
 .PP
-.VL 4m
-.LI "\*L-a """"text""""\*O"
-Specifies a quoted string to be spoken, at the end of 
-which the program returns to the shell command prompt.
-.LI "\*L-d #\*O"
+.TP
+.BI \-a text
+Specifies a quoted string to be spoken,
+at the end of which the program returns to the shell command prompt.
+.TP
+.BI \-d #
 Selects the audio output device.
-.LI "\*L-e #\*O"
+.TP
+.BI \-e #
 Selects the output wave file format, an integer in the range 1 to 3:
-.nf
-1 - PCM, 16 bit Mono 11 KHz format
-2 - PCM, 8 bit Mono 11 KHz format
-3 - Mu-law, 8 bit Mono 8 KHz format
-.fi
-.LI "\*L-fi <filename>\*O"
+.RS
+.TP
+1
+PCM, 16 bit Mono 11 KHz format
+.TP
+2
+PCM, 8 bit Mono 11 KHz format
+.TP
+3
+Mu-law, 8 bit Mono 8 KHz format
+.RS
+.TP
+.BI \-fi filename
 Specifies the name of an input ASCII file to synthesize.
-.LI "\*L-fo <filename>\*O"
-Specifies the output wave file name.  The name defaults to the
-dtmemory.c filename.
-.LI "\*L-h\*O"
+.TP
+.BI \-fo filename
+Specifies the output wave file name.
+The name defaults to
+.BR dtmemory.c .
+.TP
+.B \-h
 Displays the command line parameter list.
-.LI "\*L-r #\*O"
+.TP
+.BI \-r #
 Specifies the speaking rate (75 to 650).
-.LI "\*L-s #\*O"
+.TP
+.BI \-s #
 Selects the speaker (1 to 9).
-.LE
 .SH DESCRIPTION
 .PP
-The say program is a command line program that 
-produces synthesized audio of the input ascii text. 
+The say program is a command line program
+that produces synthesized audio
+of the input ascii text.
 .SH EXAMPLES
 .PP   
 .nf
@@ -72,8 +86,8 @@ produces synthesized audio of the input ascii text.
 .fi             
 .SH RELATED INFORMATION
 .PP
-\*Ldectalk\*O(1dtk), \*Laudiocontrol\*O(1mms), \*Lmmeserver\*O(1mms)
+.BR dectalk (1dtk),
+.BR audiocontrol (1mms),
+.BR mmeserver (1mms)
 .PP
 DECtalk Software Programmer's Guide
-
-

--- a/src/docsosf/man/man1/speak.1
+++ b/src/docsosf/man/man1/speak.1
@@ -14,46 +14,51 @@
 .\" 
 .\" $EndLog$
 .\"
-.\" This manpage source uses rsml coding. 
 .\"
-.so /usr/share/lib/tmac/sml
-.so /usr/share/lib/tmac/rsml
-.\"
-.TH speak 1dtk "" "" "" "DECtalk" ""
+.TH SPEAK 1dtk "" "" "" "DECtalk" ""
 .SH NAME
-.PP
-\*Lspeak\*O \- Simple text editor that can read using DECtalk Software
+speak \- Simple text editor that can read using DECtalk Software
 .SH SYNOPSIS
 .PP
-.sS
-\*Lspeak [-device #] [-encoding #] [-file <filename>] [-help]\*O
-.sE
+.B speak
+[\fB-device\fP \fI#\fP]
+[\fB-encoding\fP \fI#\fP]
+[\fB-file\fP \fIfilename\fP]
+[\fB-help\fP]
 .SH FLAGS
-.PP
-.VL 4m
-.LI "\*L-device #\*O"
+.TP
+.BI -device #
 Selects the audio device (0 or 1).
-.LI "\*L-encoding #\*O"
+.TP
+.BI -encoding #
 Selects the encoding, as follows:
-.nf
-1 for PCM, 16 bit Mono 11.025KHz format
-2 for PCM, 8 bit Mono 11.025KHz format
-3 for MULAW, 8 bit Mono 8KHz format
-.fi
-.LI "\*L-file <filename> #\*O"
+.RS
+.TP
+1
+PCM, 16 bit Mono 11.025KHz format
+.TP
+2
+PCM, 8 bit Mono 11.025KHz format
+.TP
+3
+MULAW, 8 bit Mono 8KHz format
+.RS
+.TP
+.BI -file filename
 Specifies a file for speak to use.
-.LI "\*L-help\*O"
+.TP
+.BI -help
 Displays help text.
-.LE
 .SH DESCRIPTION
-.PP    
-The \*Lspeak\*O application is provided in the
-DECtalk Software kit.  (For Tru64 UNIX, it
-is bundled with the runtime kit).
-The application demonstrates the capabilities 
-of DECtalk Software. 
+.PP
+The \fBspeak\fP application is provided in the DECtalk Software kit.
+(For Tru64 UNIX,
+it is bundled with the runtime kit).
+The application demonstrates the capabilities of DECtalk Software.
 .SH RELATED INFORMATION
 .PP
-\*Ldectalk\*O(1dtk), \*Laudiocontrol\*O(1mms), \*Lmmeserver\*O(1mms)
+.BR dectalk (1dtk),
+.BR audiocontrol (1mms),
+.BR mmeserver (1mms)
 .PP
 DECtalk Software Programmer's Guide

--- a/src/docsosf/man/man1/windict.1
+++ b/src/docsosf/man/man1/windict.1
@@ -12,87 +12,95 @@
 .\" 
 .\" $EndLog$
 .\"
-.\" This manpage source uses rsml coding. 
 .\"
-.so /usr/share/lib/tmac/sml
-.so /usr/share/lib/tmac/rsml
-.\"
-.TH windict 1dtk "" "" "" "DECtalk" ""
+.TH WINDICT 1dtk "" "" "" "DECtalk" ""
 .SH NAME
-.PP
-\*Lwindict\*O \- DECtalk Software dictionary building tool
+windict \- DECtalk Software dictionary building tool
 .SH SYNOPSIS
 .PP 
-.sS
-\*Lwindict\*O
-.sE
+.B windict
+[\fB\-h\fP]
 .SH FLAGS
 .PP
-.VL 4m
-.LI "\*L-h\*O"
+.TP
+.B \-h
 Displays help text
-.LE
 .SH DESCRIPTION
 .PP
-The windict program allows you to compile a dictionary work file, containing
-words or acronyms for which you have changed the pronunciation, into a user
-dictionary.  The user dictionary can then be loaded into DECtalk Software
-applications.
+The windict program allows you to compile a dictionary work file,
+containing words or acronyms for which you have changed the pronunciation,
+into a user dictionary.
+The user dictionary can then be loaded into DECtalk Software applications.
 .PP
-(A related program, userdict, allows you to compile a user dictionary from a
-file.)
+(A related program, userdict, allows you to compile a user dictionary from a file.)
 .PP
-The syntax for a dictionary entry is a word or letter string to be
-pronounced (called a grapheme string), followed by a phoneme string.  For
-example:  coffee [t'iy].  An entry line can have up to 256 characters.
+The syntax for a dictionary entry
+is a word or letter string to be pronounced
+(called a grapheme string),
+followed by a phoneme string.
+For example:  coffee [t'iy].
+An entry line can have up to 256 characters.
 .PP
-A grapheme (letter) string is comprised of legal graphemes. Legal 
-graphemes are: a-z, 0-9 and select punctuation marks (", !, @, &, (, 
-), -, \, and /).  These characters cannot be used at the beginning of
-the grapheme string. Uppercase letters match only uppercase; lowercase 
-letters match either uppercase or lowercase.
+A grapheme (letter) string is comprised of legal graphemes.
+Legal graphemes are: a-z, 0-9 and select punctuation marks (", !, @, &, (,), -, \, and /).
+These characters cannot be used at the beginning of the grapheme string.
+Uppercase letters match only uppercase;
+lowercase letters match either uppercase or lowercase.
 .PP
-The phoneme string is made up of legal phonemes.  Phonemes are always 
-in square brackets but may be in either uppercase or lowercase. For 
-example, to pronounce the word "coffee" as "tea", enter the following:
+The phoneme string is made up of legal phonemes.
+Phonemes are always in square brackets but may be in either uppercase or lowercase.
+For example, to pronounce the word "coffee" as "tea",
+enter the following:
 .PP
 coffee  [t'iy]
 .PP
-For Linux systems, if you want the dictionary just created to
-become your default user 
-dictionary, copy it into your login directory and rename it 
-\*Ludict_xx.dic\*O, where xx designates the language
-for which it is intended (us, uk, sp, la, gr, fr).
-Every time you run \*Lspeak\*O,
-it will automatically load \*Ludict_xx.dic\*O as the default
-user dictionary for the particular language.
+For Linux systems,
+if you want the dictionary just created
+to become your default user dictionary,
+copy it into your login directory and rename it
+.BR udict_xx.dic ,
+where xx designates the language
+for which it is intended
+(us, uk, sp, la, gr, fr).
+Every time you run \fBspeak\fP,
+it will automatically load
+.B udict_xx.dic
+as the default user dictionary for the particular language.
 .PP
-For Tru64 UNIX systems, if you want the dictionary just created to
-become your default user 
-dictionary, copy it into your login directory and rename it 
-\*Luser.dic\*O. Every time you run \*Lspeak\*O, it will automatically 
-load \*Luser.dic\*O as the default user dictionary.
+For Tru64 UNIX systems,
+if you want the dictionary just created
+to become your default user dictionary,
+copy it into your login directory and rename it 
+.BR user.dic .
+Every time you run \fBspeak\fP,
+it will automatically load
+.B user.dic
+as the default user dictionary.
 .PP
-Dictionary files other than default user dictionaries have no name or location
-restrictions other than those of your operating system. These files can be
-loaded whenever you want to use them. 
+Dictionary files other than default user dictionaries
+have no name or location restrictions other than those of your operating system.
+These files can be loaded whenever you want to use them.
 .SH RESTRICTIONS
 .PP
-A dictionary entry must start at the first character of the line.  Starting
-on any character other than the first makes the line a comment, and it will
-not be processed.
+A dictionary entry must start at the first character of the line.
+Starting on any character other than the first makes the line a comment,
+and it will not be processed.
 .PP
-Input files have a default extension of .tab but can be any legal 
-alphanumeric. Output dictionary files have the extension of .dic and must 
-have that extension for the loader to find the file correctly. If no 
-output file is specified, a file with the same name and .dic 
-extension is created for the output.
+Input files have a default extension of .tab
+but can be any legal alphanumeric.
+Output dictionary files have the extension of .dic
+and must have that extension for the loader to find the file correctly.
+If no output file is specified,
+a file with the same name and .dic extension is created for the output.
 .PP
-Assume that DECtalk Software pronounces all words, even the most 
-difficult ones, correctly. Unknown words are searched in the order in 
-which they are loaded.
+Assume that DECtalk Software pronounces all words,
+even the most difficult ones, correctly.
+Unknown words are searched in the order in which they are loaded.
 .SH RELATED INFORMATION
 .PP
-\*Ldectalk\*O(1dtk), \*Lspeak\*O(1dtk), \*Lsay\*O(1dtk), \*Laclock\*O(1dtk)
+.BR dectalk (1dtk),
+.BR speak (1dtk),
+.BR say (1dtk),
+.BR aclock (1dtk)
 .PP
 DECtalk Software Programmer's Guide


### PR DESCRIPTION
The manpages use some weird macro set which doesn't seem to be available
anymore.

So far I've only done this for the section 1 manpages, but there is also section
3 to be delt with.
