### PR TITLE
Fix building gspeak on macOS

### DIFF
--- a/src/dapi/src/lts/l_gr_ru1.c
+++ b/src/dapi/src/lts/l_gr_ru1.c
@@ -48,7 +48,7 @@
 #define MAXBUCH 50	
 #define UMLMRK 	16
 
-extern ls_rule_show_phone(PHONE *, PHONE *, char *); // NAL warning removal
+extern int ls_rule_show_phone(PHONE *, PHONE *, char *); // NAL warning removal
 extern int ls_adju_is_cons(PHONE *); 				 // NAL warning removal
 
 

--- a/src/dtalkml/src/dtalk_ml.c
+++ b/src/dtalkml/src/dtalk_ml.c
@@ -462,7 +462,7 @@ unsigned int load_dectalk(char *lang)
 	funcs->TextToSpeechOpenWaveOutFile = (MMRESULT ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechOpenWaveOutFile");
 	funcs->TextToSpeechCloseWaveOutFile = (MMRESULT ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechCloseWaveOutFile");
 	funcs->TextToSpeechGetStatus = (MMRESULT ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechGetStatus");
-	funcs->TextToSpeechReset = (MMRESULT ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechReset");
+	funcs->TextToSpeechReset = (MMRESULT ((_cdecl*)(LPTTS_HANDLE_T, BOOL))) GetProcAddress(funcs->mod,"TextToSpeechReset");
 	funcs->TextToSpeechSync = (MMRESULT ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechSync");
 	funcs->TextToSpeechGetRate = (MMRESULT ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechGetRate");
 	funcs->TextToSpeechSetRate = (MMRESULT ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechSetRate");
@@ -487,10 +487,10 @@ unsigned int load_dectalk(char *lang)
 
 	funcs->TextToSpeechVersion = (ULONG ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechVersion");
 	// CAB	Removed warnings 6/24/02
-	funcs->TextToSpeechTyping = (VOID ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechTyping");
+	funcs->TextToSpeechTyping = (VOID ((_cdecl*)(LPTTS_HANDLE_T, unsigned char))) GetProcAddress(funcs->mod,"TextToSpeechTyping");
 
 	funcs->TextToSpeechGetLastError = (ULONG ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechGetLastError");
-	funcs->TextToSpeechReserved1 = (ULONG ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechReserved1");
+	funcs->TextToSpeechReserved1 = (ULONG ((_cdecl*)(unsigned char*, U8, BOOL, BOOL))) GetProcAddress(funcs->mod,"TextToSpeechReserved1");
 	// CAB	Removed warnings 6/24/02
 	funcs->TextToSpeechReserved2 = (ULONG ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechReserved2");
 
@@ -504,9 +504,9 @@ unsigned int load_dectalk(char *lang)
 	funcs->TextToSpeechSetSpeakerParams = (DWORD ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechSetSpeakerParams");
 	
 	// CAB	Removed warnings 6/24/02
-	funcs->TextToSpeechDictionaryHit = (DWORD ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechDictionaryHit");
+	funcs->TextToSpeechDictionaryHit = (int ((_cdecl*)(LPTTS_HANDLE_T, struct dic_entry *))) GetProcAddress(funcs->mod,"TextToSpeechDictionaryHit");
 	funcs->TextToSpeechDumpDictionary = (DWORD ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechDumpDictionary");
-	funcs->TextToSpeechUserDictionaryHit = (DWORD ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechUserDictionaryHit");
+	funcs->TextToSpeechUserDictionaryHit = (int ((_cdecl*)(LPTTS_HANDLE_T, struct dic_entry *))) GetProcAddress(funcs->mod,"TextToSpeechUserDictionaryHit");
 	funcs->TextToSpeechDumpUserDictionary = (DWORD ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechDumpUserDictionary");
 	funcs->TextToSpeechAddUserEntry = (DWORD ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechAddUserEntry");
 	funcs->TextToSpeechDeleteUserEntry = (DWORD ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechDeleteUserEntry");
@@ -515,7 +515,7 @@ unsigned int load_dectalk(char *lang)
 	funcs->TextToSpeechConvertToPhonemes = (DWORD ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechConvertToPhonemes");
 	/* MGS added TextToSpeechTuning 12/03/1998 */
 	funcs->TextToSpeechTuning = (DWORD ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechTuning");
-	funcs->TextToSpeechGetPhVdefParams = (DWORD ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechGetPhVdefParams");
+	funcs->TextToSpeechGetPhVdefParams = (short *((_cdecl*)(LPTTS_HANDLE_T, UINT))) GetProcAddress(funcs->mod,"TextToSpeechGetPhVdefParams");
 
 	funcs->TextToSpeechSetVolume = (MMRESULT ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechSetVolume");
 	funcs->TextToSpeechGetVolume = (MMRESULT ((_cdecl*)())) GetProcAddress(funcs->mod,"TextToSpeechGetVolume");

--- a/src/samplosf/src/dtsamples/dtmemory.c
+++ b/src/samplosf/src/dtsamples/dtmemory.c
@@ -210,7 +210,7 @@ static void usage()
 **     None
 **
 **************************************************************************/
-main( int argc, char *argv[] )
+int main( int argc, char *argv[] )
 {
     int devNo		= (int)WAVE_MAPPER;
     int speaker_id 	= -1;

--- a/src/samplosf/src/speak/Makefile.in
+++ b/src/samplosf/src/speak/Makefile.in
@@ -71,7 +71,7 @@ GSPEAK_ALL_OBJS= $(GSPEAK_OBJS) $(GSPEAK_DEMO_OBJS)
 #all: $(OUTPUT_DIR_2)/speak $(OUTPUT_DIR_2)/speak.uid
 all: $(SPEAK_ALL)
 
-$(OUTPUT_DIR_2)/gspeak:$(GSPEAK_OBJS) ../../../dtalkml/build/$(OS_VERSION)/$(LANG_CODE)/$(ML_OUT)/libtts.so 
+$(OUTPUT_DIR_2)/gspeak:$(GSPEAK_OBJS) ../../../dtalkml/build/$(OS_VERSION)/$(LANG_CODE)/$(ML_OUT)/$(ML_SONAME)
 	$(RM) $@
 	$(CC) -o $@ $(GSPEAK_OBJS) $(GLINK_FLAGS) $(G_DT_LIB) $(GLIBS)
 
@@ -89,7 +89,7 @@ $(OUTPUT_DIR_2)/link/gspeak.o:gspeak.c
 $(OUTPUT_DIR_2)/link/gspeakdem_$(LANG_CODE).o:gspeak.c
 	$(CC) -c -DDEMO -D$(LANGUAGE) $(GCFLAGS) -o $@ $<
 
-$(OUTPUT_DIR_2)/speak:$(SPEAK_OBJS) ../../../dtalkml/build/$(OS_VERSION)/$(LANG_CODE)/$(ML_OUT)/libtts.so
+$(OUTPUT_DIR_2)/speak:$(SPEAK_OBJS) ../../../dtalkml/build/$(OS_VERSION)/$(LANG_CODE)/$(ML_OUT)/$(ML_SONAME)
 	$(RM) $@
 	$(CC) -o $@ $(SPEAK_OBJS) $(LINKFLAGS) $(XLIBS) $(DT_LIB) $(LIBS) $(MMELIBS)
 

--- a/src/samplosf/src/speak/gspeak.c
+++ b/src/samplosf/src/speak/gspeak.c
@@ -762,7 +762,18 @@ int main (int argc, char *argv[])
   if (config_file==NULL)
   {
 	  char p[PATH_MAX] = {};
-	  ssize_t count = readlink("/proc/self/exe", p, PATH_MAX);
+#if defined(__linux__)
+		ssize_t count = readlink("/proc/self/exe", p, PATH_MAX);
+#elif defined(__APPLE__)
+		char ep[PATH_MAX] = {};
+		uint32_t size = sizeof(ep);
+		ssize_t count = -1;
+		if (_NSGetExecutablePath(ep, &size) == 0) {
+			if (realpath(ep, p) != NULL) {
+				count = strlen(p);
+			}
+		}
+#endif
 	  if (count != -1) {
 		  char *cfg;
 		  cfg = dirname(p);
@@ -779,7 +790,18 @@ int main (int argc, char *argv[])
   if (config_file==NULL)
   {
 	  char p[PATH_MAX] = {};
-	  ssize_t count = readlink("/proc/self/exe", p, PATH_MAX);
+#if defined(__linux__)
+		ssize_t count = readlink("/proc/self/exe", p, PATH_MAX);
+#elif defined(__APPLE__)
+		char ep[PATH_MAX] = {};
+		uint32_t size = sizeof(ep);
+		ssize_t count = -1;
+		if (_NSGetExecutablePath(ep, &size) == 0) {
+			if (realpath(ep, p) != NULL) {
+				count = strlen(p);
+			}
+		}
+#endif
 	  if (count != -1) {
 		  char *cfg;
 		  cfg = dirname(p);
@@ -821,7 +843,18 @@ int main (int argc, char *argv[])
 #if defined __linux || defined (__APPLE__)
 	if (exe_path && (bitmap_path[0] != '/')) {
 	   char p[PATH_MAX] = {};
-	   ssize_t count = readlink("/proc/self/exe", p, PATH_MAX);
+#if defined(__linux__)
+		 ssize_t count = readlink("/proc/self/exe", p, PATH_MAX);
+#elif defined(__APPLE__)
+		 char ep[PATH_MAX] = {};
+		 uint32_t size = sizeof(ep);
+		 ssize_t count = -1;
+		 if (_NSGetExecutablePath(ep, &size) == 0) {
+			 if (realpath(ep, p) != NULL) {
+				 count = strlen(p);
+			 }
+		 }
+#endif
 	   if (count != -1) {
 	     char *bmp;
 	     bmp = dirname(p);
@@ -1951,7 +1984,18 @@ void HelpAboutCallback(GtkWidget *w, gpointer data)
   if (config_file==NULL)
   {
 	  char p[PATH_MAX] = {};
-	  ssize_t count = readlink("/proc/self/exe", p, PATH_MAX);
+#if defined(__linux__)
+		ssize_t count = readlink("/proc/self/exe", p, PATH_MAX);
+#elif defined(__APPLE__)
+		char ep[PATH_MAX] = {};
+		uint32_t size = sizeof(ep);
+		ssize_t count = -1;
+		if (_NSGetExecutablePath(ep, &size) == 0) {
+			if (realpath(ep, p) != NULL) {
+				count = strlen(p);
+			}
+		}
+#endif
 	  if (count != -1) {
 		  char *cfg;
 		  cfg = dirname(p);
@@ -1965,7 +2009,18 @@ void HelpAboutCallback(GtkWidget *w, gpointer data)
   if (config_file==NULL)
   {
 	  char p[PATH_MAX] = {};
-	  ssize_t count = readlink("/proc/self/exe", p, PATH_MAX);
+#if defined(__linux__)
+		ssize_t count = readlink("/proc/self/exe", p, PATH_MAX);
+#elif defined(__APPLE__)
+		char ep[PATH_MAX] = {};
+		uint32_t size = sizeof(ep);
+		ssize_t count = -1;
+		if (_NSGetExecutablePath(ep, &size) == 0) {
+			if (realpath(ep, p) != NULL) {
+				count = strlen(p);
+			}
+		}
+#endif
 	  if (count != -1) {
 		  char *cfg;
 		  cfg = dirname(p);
@@ -2006,7 +2061,18 @@ void HelpAboutCallback(GtkWidget *w, gpointer data)
 #if defined __linux || defined (__APPLE__)
 	if ((access(bitmap_path, R_OK) == -1) && (bitmap_path[0] != '/')) {
 	   char p[PATH_MAX] = {};
-	   ssize_t count = readlink("/proc/self/exe", p, PATH_MAX);
+#if defined(__linux__)
+		 ssize_t count = readlink("/proc/self/exe", p, PATH_MAX);
+#elif defined(__APPLE__)
+		 char ep[PATH_MAX] = {};
+		 uint32_t size = sizeof(ep);
+		 ssize_t count = -1;
+		 if (_NSGetExecutablePath(ep, &size) == 0) {
+			 if (realpath(ep, p) != NULL) {
+				 count = strlen(p);
+			 }
+		 }
+#endif
 	   if (count != -1) {
 	     char *bmp;
 	     bmp = dirname(p);

--- a/src/samplosf/src/windict/compile_dict.c
+++ b/src/samplosf/src/windict/compile_dict.c
@@ -105,7 +105,7 @@
 #include <sys/stat.h>
 #include <stdio.h>
 #include <time.h>
-#include <malloc.h>
+#include <string.h>
 #include "port.h"
 #include "cmd.h"
 
@@ -263,6 +263,15 @@ void pushEntry();
 unsigned char nonWhite();
 unsigned char getAlpha();
 int look_for_prefix(char, char);
+int get_entry(char*);
+int parseString(char*);
+void scan_entry();
+void sort_entry();
+void scan_error(char*);
+int legal_alpha(char);
+int validatePrefixStr(char*);
+int validatePostfixStr(char*);
+int skipBlanks(char*);
 
 
 /*
@@ -305,7 +314,7 @@ unsigned char case_upper[] = {
 	0xf8,		0xf9,		0xfa,		0xfb,		0xfc,		0xfd,		0xfe,		0xff,
 };
 
-compile_dictonary(char *DictFile, char *text, char *errStr)
+void compile_dictonary(char *DictFile, char *text, char *errStr)
 {
 
 	char	 fnam_d[80];
@@ -393,7 +402,7 @@ compile_dictonary(char *DictFile, char *text, char *errStr)
  */
 
 
-sort_entry()
+void sort_entry()
 {
 	unsigned char *ct,*dt;
 	unsigned int *blink,next;
@@ -438,7 +447,7 @@ sort_entry()
  *  <entry> {1 char phonemes}
  */
 
-scan_entry()
+void scan_entry()
 {
 	unsigned char c;
 
@@ -691,7 +700,7 @@ int lookupArpabet(p1,p2)
  *  of the user dictionary ...
  */
 
-scan_error(es)
+void scan_error(es)
 char *es;
 {
 	int	i;
@@ -725,11 +734,11 @@ unsigned char getAlpha()
 	if(line[curr_char] == ' ' || line[curr_char] == '\t')
 		return(' ');
 	scan_error("Unknown alphabetic character");
-        return;
+        return('\0');
 }
 
 unsigned char legal_graphs[] = "_-()&@*!\\/";
-legal_alpha(c)
+int legal_alpha(c)
 char c;
 {
 	int	i;
@@ -832,7 +841,9 @@ int validatePrefixStr( char * prefixStr )
            (prefixStr[idx] != ' ') && 
            (prefixStr[idx] != 0) )
       {
-         scan_error("Not alpha numeric 0x%x\n", prefixStr[idx]);
+         char err[32];
+         sprintf(err, "Not alpha numeric 0x%x\n", prefixStr[idx]);
+         scan_error(err);
          validStr = FALSE; 
          break;
       }

--- a/src/samplosf/src/windict/windic.c
+++ b/src/samplosf/src/windict/windic.c
@@ -94,6 +94,7 @@ void Error(char*, int);
 void CheckFileExtension(int, char *);
 void SaveMsg(void);
 char *strip_filename(gchar *);
+void compile_dictonary(char *, char *, char *);
 
 
 

--- a/src/udicunix/src/udic_com.c
+++ b/src/udicunix/src/udic_com.c
@@ -155,7 +155,7 @@ unsigned int arpabet_lang_fonts[] = {
 int look_for_prefix(char p1, char p2);
 
 
-main(int argc,char *argv[])
+int main(int argc,char *argv[])
 
 {
 #if defined __linux__ || defined __osf__ || defined __ppc__ || defined (__APPLE__)


### PR DESCRIPTION
Fix some warnings that are errors on modern Clang, specifically `incompatible-function-pointer-types`, `implicit-int` and `implicit-function-declaration`. Also, ensure the build uses `libtts.dylib` on macOS and fix paths to resources.