### PR TITLE
dtalk_ml.c: add missing headers for macOS

### DIFF
--- a/src/dtalkml/src/dtalk_ml.c
+++ b/src/dtalkml/src/dtalk_ml.c
@@ -114,6 +114,9 @@ _CRTIMP wchar_t __cdecl towupper(wchar_t);
 #include <linux/limits.h>
 #elif defined (__APPLE__)
 #include <limits.h>
+#include <stdint.h>
+#include <sys/types.h>
+#include <mach-o/dyld.h>
 #endif
 #include <libgen.h>
 #endif // linux

--- a/src/samplosf/src/speak/gspeak.c
+++ b/src/samplosf/src/speak/gspeak.c
@@ -56,6 +56,10 @@ TODO:
 #include <locale.h>
 #endif
 
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
+
 #define ZERO            0
 #define SPEAKING_VOICES 9
 #define NUM_LANGS       6

--- a/src/samplosf/src/windict/windic.c
+++ b/src/samplosf/src/windict/windic.c
@@ -69,8 +69,11 @@
 #include <strings.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>   
+#include <unistd.h>
 
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
 
 #define NUM_LANGS           6
 


### PR DESCRIPTION
Same issue as with another file which was fixed previously.