### PR TITLE
Documentation adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ apt-get install build-essential libasound2-dev libpulse-dev libgtk2.0-dev unzip 
 </details>
 <details>
 <summary>Compiling on Linux</summary>
-make sure you have the autoconf, automake, and gcc packages installed
   
 ```sh
+# make sure you have the autoconf, automake, and gcc packages installed before proceeding
+
 # Run all these commands in the /src directory...
 cd src
 

--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ apt-get install build-essential libasound2-dev libpulse-dev libgtk2.0-dev unzip 
 </details>
 <details>
 <summary>Compiling on Linux</summary>
-
+make sure you have the autoconf, automake, and gcc packages installed
+  
 ```sh
 # Run all these commands in the /src directory...
 cd src
 
 # Generates configure files
-autoreconf -si
+./autogen.sh
 
 # Executes configure files
 ./configure


### PR DESCRIPTION
the autogen.sh script seems to have higher reliability compared to the original linux instructions.
this change also includes a small hint about some packages than may be required to compile DECtalk.