### PR TITLE
Fix buffer overflow crash in f_fr_ru1.c.

### DIFF
--- a/src/dapi/src/lts/l_fr_ru1.c
+++ b/src/dapi/src/lts/l_fr_ru1.c
@@ -177,17 +177,18 @@ BYTE Ph2 [100];
 */
 void ls_rule_lts(LPTTS_HANDLE_T phTTS,LETTER *llp, LETTER *rlp, FLAG ContD) 
 {
-	unsigned char precednor [80];
-	unsigned char phrase    [80];
-	unsigned char phrasenor [80];
-	unsigned char suivant   [80];
-	unsigned char phon      [80];
+	unsigned char precednor [128];
+	unsigned char phrase    [128];
+	unsigned char phrasenor [128];
+	unsigned char suivant   [128];
+	unsigned char phon      [128];
 	unsigned char *lph;
 	LETTER *ls1;
 	LETTER *lste;
 	PLTS_T pLts_t = phTTS->pLTSThreadData;
 	lste = ls1 = llp;
 	
+
 	
 	lph = phrase;
 	while (ls1<rlp) 

--- a/src/dapi/src/lts/ls_data.h
+++ b/src/dapi/src/lts/ls_data.h
@@ -231,8 +231,8 @@ typedef struct LTS_TAG
 	short PtPilSauv;  	/* first free in PilSauv */
 	TypTamp Tamp;
 	BYTE F_CodBl;  /* this must be defined before Ph1 and Ph2 */
-	BYTE Ph1 [100];
-	BYTE Ph2 [100];
+	BYTE Ph1 [128];
+	BYTE Ph2 [128];
   	FLAG  contgc;  /* current word is left context for next word */
 #endif
 } LTS_T;

--- a/src/dapi/src/lts/ls_data.h
+++ b/src/dapi/src/lts/ls_data.h
@@ -225,7 +225,7 @@ typedef struct LTS_TAG
 #endif
 
 #if defined FRENCH || defined EPSON_ARM7
-	char precedent [80]; //contains the preceding word in ascii
+	char precedent [128]; //contains the preceding word in ascii
 	/* left string shorter than the current one */
 	short PilSauv [LgPile];
 	short PtPilSauv;  	/* first free in PilSauv */


### PR DESCRIPTION
I discovered a crash in French DECtalk if you ask `say` to speak a very long word.

To reproduce, run the following command (asked `say` to speak a * 512):
```
say -l fr -a "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
```
On my Linux box (Ubuntu 24.04 LTS, GCC 13.3.0), this results in the stack canary being corrupted and the program aborting:
```
say -l fr -a "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
*** buffer overflow detected ***: terminated
```
I used GDB to trace this problem down to the fact that `ls_rule_lts` in `f_fr_ru1.c` only allocates 80 bytes for `phrase`, despite the fact that the string formed by `llp` to `rlp` can be up to 128 bytes long (127 ASCII + null term). I also found that  `char precedent []` within the `LTS_T` struct in `ls_data.h` was also 80 bytes. I increased the size of each c-string to 128 bytes, and the crash no longer occurs. 

I determined the 128-byte size by printing the string length reported in `ls_rule_lts` when running the first command. This is confirmed by `cword` and `nword` in `LTS_T` being `NGWORD` bytes long (128 bytes, as defined in `ls_defs.h`.