### PR TITLE
NVDA: Update files for 2025.1 compatibility

### DIFF
--- a/src/nvda/manifest.ini
+++ b/src/nvda/manifest.ini
@@ -4,4 +4,4 @@ version = 1.4
 description = This is the DECtalk synthesizer for NVDA
 author = NVDA User
 minimumNVDAVersion = 2019.3.0
-lastTestedNVDAVersion = 2024.1
+lastTestedNVDAVersion = 2025.1

--- a/src/nvda/synthDrivers/dectalk.py
+++ b/src/nvda/synthDrivers/dectalk.py
@@ -142,9 +142,8 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		synthDriverHandler.SynthDriver.RateSetting(),
 		synthDriverHandler.SynthDriver.PitchSetting(),
 		synthDriverHandler.SynthDriver.InflectionSetting(),
-	)
-	if usingWasapiWavePlayer(): supportedSettings+=(synthDriverHandler.SynthDriver.VolumeSetting(),)
-	supportedSettings+=(NumericDriverSetting("spf", _("&SPF"), True, defaultVal=50),
+		synthDriverHandler.SynthDriver.VolumeSetting(),
+		NumericDriverSetting("spf", _("&SPF"), True, defaultVal=100),
 		BooleanDriverSetting("pauses", _("&Shorten pauses"), True, defaultVal=True),
 	)
 	supportedCommands = {
@@ -238,7 +237,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 		self.mem_buffer.dwMaximumNumberOfIndexMarks = INDEX_ARRAY_SIZE
 		dectalk.TextToSpeechOpenInMemory(self.handle, FORMAT)
 		dectalk.TextToSpeechAddBuffer(self.handle, byref(self.mem_buffer))
-		self.player = WavePlayer(1, 11025, 16, outputDevice=config.conf["speech"]["outputDevice"])
+		self.player = WavePlayer(1, 11025, 16, outputDevice=config.conf["audio"]["outputDevice"])
 		self.audioQueue = SimpleQueue()  # For audio and indexes.
 		self.audio_thread = BgThread(self.audioQueue)
 		self.audio_thread.start()


### PR DESCRIPTION
This pull request aims to update the NVDA add-on's files to work with 2025.1. These changes have been tested and proven to work with the latest version of NVDA. It should also improve responsiveness due to the screen reader now using WASAPI for audio output. The default SPF parameter was also changed from 50 to 100.