### PR TITLE
Fixed spoken text when using the version speak command.

### DIFF
--- a/src/dapi/src/cmd/cm_copt.c
+++ b/src/dapi/src/cmd/cm_copt.c
@@ -2084,7 +2084,7 @@ int cm_cmd_version(LPTTS_HANDLE_T phTTS)
 				}
 			}
 			/* Taken from DTC-01 firmware, including misspelling(?) of hear */
-			sprintf(versionstr, "\rHello. This is DECtalk. The software version is %d point %d %s. The code memories were generated on %s-%s-%s. The dictionary memories were generated on %s-%s-%s. There are many bytes free. If you can here this, there is a good chance that your DECtalk is working.\r",
+			sprintf(versionstr, "\rHello. This is DECtalk. The software is version %d point %d %s. The code memories were generated on %s-%s-%s. The dictionary memories were generated on %s-%s-%s. There are many bytes free. If you can hear this, there is a good chance that your DECtalk is working.\r",
 				DTALK_MAJ_VERSION, DTALK_MIN_VERSION, RELEASE,
 				datepart[0], datestr, datepart[1], datepart[0], datestr, datepart[1]);
 

--- a/src/dapi/src/cmd/cm_copt.c
+++ b/src/dapi/src/cmd/cm_copt.c
@@ -2084,7 +2084,7 @@ int cm_cmd_version(LPTTS_HANDLE_T phTTS)
 				}
 			}
 			/* Taken from DTC-01 firmware, including misspelling(?) of hear */
-			sprintf(versionstr, "\rHello. This is DECtalk. The software is version %d point %d %s. The code memories were generated on %s-%s-%s. The dictionary memories were generated on %s-%s-%s. There are many bytes free. If you can hear this, there is a good chance that your DECtalk is working.\r",
+			sprintf(versionstr, "\rHello. This is DECtalk. The software is version %d point %d %s. The code memories were generated on %s-%s-%s. The dictionary memories were generated on %s-%s-%s. There are many bytes free. If you can here this, there is a good chance that your DECtalk is working.\r",
 				DTALK_MAJ_VERSION, DTALK_MIN_VERSION, RELEASE,
 				datepart[0], datestr, datepart[1], datepart[0], datestr, datepart[1]);
 


### PR DESCRIPTION
The text spoken when using the version speak command is now closer to the original hardware unit. It now says "The software is version..." in stead of "The software version is...", and the word "hear" was misspelled as "here", which has also now been corrected.