### PR TITLE
Fix audio stalling on Linux when new text is queued shortly after previous text has concluded.

### DIFF
--- a/src/dapi/src/nt/linux_audio.c
+++ b/src/dapi/src/nt/linux_audio.c
@@ -1345,6 +1345,7 @@ static	BOOL	wodPlayer_WriteFragments(WINE_WAVEOUT* wwo)
 	if (wwo->dwLastFragDone /* + guard time ?? */ < tc) {
           wwo->server_startticks = 0;
           wwo->server_startticks = GetTickCount(wwo);
+          wwo->qwFragBytes = 0;
 	}
 	wwo->qwFragBytes += toWrite;
 	wwo->dwLastFragDone = (wwo->qwFragBytes * 1000) / wwo->format.wf.nAvgBytesPerSec;
@@ -1437,6 +1438,7 @@ static	BOOL	wodPlayer_WriteFragments(WINE_WAVEOUT* wwo)
 	if (wwo->dwLastFragDone /* + guard time ?? */ < tc) {
           wwo->server_startticks = 0;
           wwo->server_startticks = GetTickCount(wwo);
+          wwo->qwFragBytes = 0;        
 	}
 	wwo->qwFragBytes += wwo->dwRemain;
 	wwo->dwLastFragDone = (wwo->qwFragBytes * 1000) / wwo->format.wf.nAvgBytesPerSec;


### PR DESCRIPTION
While working on a program using DECTalk, I sometimes noticed that the audio playback of recently queued text sounded like it would cut out at the beginning. This was unusual, since on the Windows build this appeared to not be the case. To test this, I set up the following example that would trigger the problem:

```c
#include <stdio.h>
#include <string.h>
#include "ttsapi.h"

int main()
{
	LPTTS_HANDLE_T handle = nullptr;

	TextToSpeechStartupEx(&handle, WAVE_MAPPER, OWN_AUDIO_DEVICE, nullptr, 0);
	for(int i = 0; i < 10; i++)
	{
		char text_buff[20] = "";
		sprintf(text_buff, "%d", i + 1);
		TextToSpeechSpeak(handle, text_buff, 1);
		TextToSpeechSync(handle);
	}


	TextToSpeechShutdown(handle);
}
```
All that this program does is format a string with a number [1, 10] and then have DECtalk speak it. After each call to `TextToSpeechSpeak`, I call `TextToSpeechSync` to wait for the audio playback to conclude before queuing the next text. I compiled this example using `gcc -Iinclude/dtk/ -Llib/ main.c -ltts_us -o example` while in the dist directory of the DECTalk repo.

On my machine running Ubuntu 24.04.4 LTS, this produced the following audio (recorded using Audacity monitoring my builtin output):

[DECTalk stutter.wav](https://github.com/user-attachments/files/26010484/DECTalk.stutter.wav)

In reality, the audio output should sound something closer to this:

[DECTalk No Stutter.wav](https://github.com/user-attachments/files/26010506/DECTalk.No.Stutter.wav)

This issue is only isolated to Linux, as tests on the same program on Windows did not produce such long gaps between speech output. 

From what I understand, `linux_audio.c` is a borrowed/modified from an older version of the WINE project, with the goal of replicating the Windows MME audio interface so that the existing code in `playaud.c` could remain compatible with Windows. With a lot of debugging and print statements, I was able to isolate the problem to the way `linux_audio.c` handles scheduling samples.

Based on my understanding, `linux_audio.c` behaves as follows: Samples are queued from `vtmiont.c` with a call to `PA_Queue`. `PA_Queue` is responsible for placing the synthesized samples into the audio ring. Once in this ring, `StartAudioPlaying` will send these samples over to `WriteBufferToWaveDevice`, which will create a wave-out header/packet. This packet is passed into `waveOutWrite`, which through a series of messages and function calls causes this header to be queued within the `wodPlayer` function. These headers are specifically added to a queue called `lpPlayPtr`, a queue of samples that have yet to be played. 

`wodPlayer` is the function responsible for triggering the playback of the queued headers by calling `wodPlayer_WriteFragments`. `wodPlayer_WriteFragments` job is to write as many as available of the queued headers in `lpPlayPtr` into the chosen audio library (ALSA, Pulse, etc). The function will only send samples to ALSA and Co. when the library can accept the samples AND when the notification queue `lpQueuePtr` is not empty (for buffer underflow conditions). The pointer to the very last header that `wodPlayer_WriteFragments` dispatches is assigned to `lpQueuePtr` to indicate it should be the last sample of what was written to be played.

`lpQueuePtr` is responsible for keeping track of headers that are currently playing-in-progress. When `lpQueuePtr == NULL`, all the currently queued samples have played, and when `lpQueuePtr != NULL` there are still samples that are currently playing. To know when all samples have been played, `wodPlayer_WriteFragments` assigns to the reserve field of the header a timestamp, milliseconds, when that sample and the ones before it will have finished playing. This calculation occurs on lines 1350 through 1351 of `linux_audio.c`.

To determine when the last batch of samples should have finished playing, `linux_audio.c` provides a function called `GetTickCount`. It returns a value, in milliseconds, from the start of the audio playback system (`wwo->server_startticks`). After each call to `wodPlayer_WriteFragments`, a call to `wodPlayer_Notify` is performed immediately after. This function calls `GetTickCount` and compares it to the reserve field of the header in `lpQueuePtr`. If the current time is greater than the completion timestamp in the header (all prior headers should have completed), `wodPlayer_notify` will update the value of `lpQueuePtr` to the next header and send a notification to DECtalk to inform of playback progress. This notification is how `TextToSpeechSync` can figure out when all the audio has played.

The cause of the stalling bug has to do with a particular set of logic in `wodPlayer_WriteFragments` responsible for updating the audio playback system start time (`wwo->server_startticks`). The logic in question is on lines 1345 through 1349, and duplicated on lines 1438 through 1442 in `linux_audio.c`:

```c
if (wwo->dwLastFragDone /* + guard time ?? */ < tc) {
      wwo->server_startticks = 0;
      wwo->server_startticks = GetTickCount(wwo);  
}
wwo->qwFragBytes += wwo->dwRemain;
wwo->dwLastFragDone = (wwo->qwFragBytes * 1000) / wwo->format.wf.nAvgBytesPerSec;
```
I believe the purpose of this logic is to prevent an 32-bit integer overflow of the elapsed time by resetting the start time to the present. The logic is guarded with `wwo->dwLastFragDone < tc`, which occurs when all previous headers have been exhausted. This normally occurs once the speech audio has fully completed and no new samples are available yet. Since no new frames are present, resetting the start time now shouldn't effect the notification time and audio should be dispatched as usual. However, the timestamp for the last fragment, `dwLastFragDone`, is calculated using the sum total of all previously played bytes. This means that even when the start time resets, the end of the next set of frames will be the length of the new series of headers plus the length of all previous headers. This is what causes the long, growing delays in the stutter version of the audio clip. 

The change I made resets `qwFragBytes` to zero at the same time the server ticks are restarted, so that the new frames are timed in reference to the new start time. `qwFragBytes` is only ever reset or set by `wodPlayer_WriteFragments`, so this change shouldn't effect any other code while retaining the original intended purpose of the code. Hopefully this change will be useful for anyone using the API instead of the included binaries (which I think might be avoiding this issue by continuously resetting DECTalk after every sync).