### PR TITLE
Add Linux modernization planning docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
+baseline-runs/
 
 # Nintendo DS
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,194 @@
+# AGENTS.md
+
+## Project goal
+
+Modernize and clean up DECtalk while preserving existing behavior.
+
+This is legacy C code with many historical platform, language, product, and feature conditionals. The code works, but it is difficult to read and produces many warnings on modern compilers. The modernization goal is to improve maintainability without changing speech output, public API behavior, generated dictionaries, packaging, or runtime behavior unless explicitly approved.
+
+## Current intended targets
+
+The intended supported targets are:
+
+- Linux
+- Windows
+- macOS
+- iOS
+
+Historical targets such as OSF/Tru64, VxWorks, MS-DOS, Windows CE, Solaris/SPARC, ARM7, MIPS, old PowerPC Mac, and iPAQ Linux may be inventoried, documented, or quarantined behind explicit legacy options, but they must not be deleted or broadly rewritten without explicit approval.
+
+## Core rule
+
+Behavior preservation is more important than cleanup.
+
+Do not perform broad refactoring, whole-repo formatting, aggressive warning cleanup, or preprocessor simplification unless the task explicitly asks for it and there is a clear verification strategy.
+
+## High-risk areas
+
+Treat these as behavior-critical:
+
+- `src/dectalkf.h`
+- `src/dectalkf_klsyn.h`
+- `src/dectalkf_hlsyn.h`
+- `src/dapi/src/api/ttsapi.h`
+- `src/dapi/src/api/tts.h`
+- `src/dapi/src/api/ttsapi.c`
+- `src/dapi/src/api/init.c`
+- `src/dapi/src/lts`
+- `src/dapi/src/ph`
+- `src/dapi/src/vtm`
+- `src/dapi/src/hlsyn`
+- `src/dapi/src/nt/opthread.c`
+- `src/dapi/src/nt/linux_audio.c`
+- dictionary loading, dictionary generation, and generated `.dic` files
+- public headers
+- exported symbols
+- audio timing, callback, pipe, queue, and threading behavior
+
+## Do not change without explicit approval
+
+Do not intentionally change:
+
+- speech output
+- phoneme output
+- timing behavior
+- default voice
+- voice ROM selection
+- parser behavior
+- intonation/timing model
+- sample rate
+- dictionary format
+- dictionary lookup behavior
+- public API signatures
+- exported symbol names
+- DLL/shared-library names
+- install layout
+- command-line behavior of existing tools
+- language selection behavior
+- threading model
+- audio backend behavior
+
+## Build systems
+
+The repository currently contains multiple build paths. Preserve them unless the task explicitly says otherwise.
+
+Expected existing build systems include:
+
+- Autotools/Make for Unix-like builds
+- Visual Studio solution/project files for Windows
+- legacy Visual Studio 6 support
+- GitHub Actions build scripts
+- custom scripts under `devops/`
+
+A new build system may be added side-by-side, but existing build systems must not be removed until parity is proven.
+
+## Preferred workflow
+
+For each task:
+
+1. Inspect before editing.
+2. Identify the files that need to change.
+3. Prefer the smallest useful change.
+4. Avoid unrelated cleanup.
+5. Build or run the narrowest relevant verification command.
+6. Summarize exactly what changed.
+7. State what was not changed.
+8. Call out uncertainty and risk.
+
+## Commit/PR style
+
+Prefer small, focused changes.
+
+Good task types:
+
+- documentation
+- baseline capture scripts
+- build-log capture
+- warning inventory
+- macro inventory
+- single-file warning cleanup
+- platform abstraction scaffolding
+- tests around existing behavior
+
+Avoid large mixed changes.
+
+## Warning cleanup policy
+
+Warnings should be reduced by category, not by random edits.
+
+Low-risk warning cleanup includes:
+
+- missing prototypes
+- missing standard includes
+- duplicate declarations
+- unused parameters
+- obviously incorrect format strings
+- local variables that need obvious initialization
+- mechanical `const` correctness where no API changes result
+
+Medium-risk warning cleanup requires caution:
+
+- signed/unsigned conversions
+- pointer/integer casts
+- size truncation
+- callback signatures
+- thread function signatures
+- `volatile` and concurrency-related warnings
+
+High-risk warning cleanup should be avoided unless explicitly requested:
+
+- arithmetic changes in synthesizer code
+- struct layout changes
+- public header changes
+- dictionary format changes
+- thread lifecycle changes
+- audio timing changes
+- parser or phoneme logic changes
+
+## Macro policy
+
+Do not remove preprocessor conditionals casually.
+
+Before simplifying macros, classify them as one of:
+
+- current platform
+- current architecture
+- language selection
+- sound-critical feature
+- product feature
+- build-system define
+- historical target
+- unknown
+
+Historical-target code should first be documented and then quarantined behind explicit legacy options before deletion is considered.
+
+## Testing and verification
+
+When possible, prefer deterministic tests that do not require live audio hardware.
+
+Useful verification artifacts include:
+
+- build logs
+- compiler warning logs
+- exported symbols
+- generated dictionaries
+- installed/dist tree manifests
+- command-line tool output
+- WAV/raw audio output from fixed input text
+- file hashes
+- sample counts
+- RMS/peak deltas for audio comparisons
+
+If no test is available, say so explicitly.
+
+## Communication style
+
+When reporting back, include:
+
+- summary
+- files changed
+- verification run
+- behavior risk
+- follow-up recommendations
+
+Do not claim behavior is preserved unless the relevant checks were run.

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -124,3 +124,23 @@ Modernization needs to preserve each build path until a replacement has proven p
 #### Follow-up
 
 Document source membership and artifact differences between Unix, VS6, and VS2022 builds.
+
+---
+
+### 2026-05-15 - Unix make can ignore missing sample artifacts
+
+#### Context
+
+Recording the first local Unix baseline capture in `baseline-runs/unix-001/`.
+
+#### Lesson
+
+The captured `make` step exited 0, but `make.log` included ignored install errors for missing `gspeak` and `windic` sample artifacts.
+
+#### Impact
+
+Baseline review must inspect logs and output manifests, not just final exit codes.
+
+#### Follow-up
+
+Capture a dist manifest for the same build output and decide whether the missing sample artifacts are expected for this environment.

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -144,3 +144,23 @@ Baseline review must inspect logs and output manifests, not just final exit code
 #### Follow-up
 
 Capture a dist manifest for the same build output and decide whether the missing sample artifacts are expected for this environment.
+
+---
+
+### 2026-05-15 - Unix warning captures can be incremental
+
+#### Context
+
+Recording the first source warning cleanup result after changing `src/licunix/src/liceninc.c`.
+
+#### Lesson
+
+The after-cleanup Unix `make.log` was much shorter than the original baseline log because `make` reused existing outputs and rebuilt only affected pieces.
+
+#### Impact
+
+Targeted warnings can still be checked, but whole-repo warning totals are not directly comparable unless the build state is cleaned or otherwise controlled.
+
+#### Follow-up
+
+Use a clean rebuild when comparing whole-repo warning counts; otherwise compare the exact targeted warning lines before and after.

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1,0 +1,126 @@
+# LESSONS.md
+
+This file records discoveries, gotchas, decisions, and project-specific lessons learned while modernizing DECtalk.
+
+The goal is to avoid rediscovering the same facts repeatedly and to help future Codex sessions preserve behavior while improving the codebase.
+
+## How to use this file
+
+Add a short entry whenever a task reveals something important, surprising, risky, or easy to forget.
+
+Good entries include:
+
+- build-system gotchas
+- macro meanings
+- platform-specific behavior
+- warning patterns
+- files that are risky to touch
+- tests that caught or failed to catch something
+- behavior that must be preserved
+- decisions made during modernization
+- commands that worked
+- commands that failed and why
+
+Keep entries concise, factual, and dated.
+
+## Entry format
+
+Each entry should use this structure:
+
+### YYYY-MM-DD - Short title
+
+#### Context
+
+What were we trying to do?
+
+#### Lesson
+
+What did we learn?
+
+#### Impact
+
+Why does it matter?
+
+#### Follow-up
+
+What should be done next, if anything?
+
+---
+
+### 2026-05-15 - Modernization must be preservation-first
+
+#### Context
+
+Initial modernization planning for the DECtalk repository.
+
+#### Lesson
+
+This repository contains legacy C code with deeply intertwined platform, language, product, and sound-critical feature conditionals. Broad cleanup or aggressive `#ifdef` removal could change behavior even when the edit looks mechanical.
+
+#### Impact
+
+Before refactoring, the project needs baseline artifacts such as build logs, warning logs, exported symbols, generated dictionaries, dist manifests, and representative audio output.
+
+#### Follow-up
+
+Start with documentation and baseline capture before source cleanup.
+
+---
+
+### 2026-05-15 - Current intended targets are narrower than historical code
+
+#### Context
+
+The modernization target platforms were identified as Linux, Windows, macOS, and iOS.
+
+#### Lesson
+
+The source still contains historical branches for older or inactive targets such as OSF/Tru64, VxWorks, MS-DOS, Windows CE, Solaris/SPARC, ARM7, MIPS, PowerPC Mac, and iPAQ Linux.
+
+#### Impact
+
+Historical branches should be inventoried and eventually quarantined behind explicit legacy options. They should not be deleted casually, because some historical macros may still affect current builds indirectly.
+
+#### Follow-up
+
+Build a macro inventory before attempting preprocessor cleanup.
+
+---
+
+### 2026-05-15 - `dectalkf_klsyn.h` is behavior-critical
+
+#### Context
+
+Initial inspection showed that `src/dectalkf_klsyn.h` controls many synthesis features.
+
+#### Lesson
+
+This file controls behavior such as parser selection, typing mode, single-threading, intonation/timing model, voice tract model, sample rate, voice ROM selection, old-song parser compatibility, and software volume.
+
+#### Impact
+
+Changes to this file can alter speech output. Treat it as sound-critical configuration, not ordinary cleanup.
+
+#### Follow-up
+
+Include it in baseline documentation and macro inventory.
+
+---
+
+### 2026-05-15 - Build systems differ by platform
+
+#### Context
+
+Initial inspection showed that Unix-like builds and Windows builds are not equivalent.
+
+#### Lesson
+
+The Unix build path uses Autotools/Make and appears to build multiple language variants. The VS2022 path currently builds `Release - ENGLISH_US` for AMD64 and IA32 through custom batch files.
+
+#### Impact
+
+Modernization needs to preserve each build path until a replacement has proven parity. A future CMake build should be added side-by-side first, not as an immediate replacement.
+
+#### Follow-up
+
+Document source membership and artifact differences between Unix, VS6, and VS2022 builds.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,286 @@
+# PLAN.md
+
+## Objective
+
+Clean up and modernize the DECtalk codebase while preserving current behavior on Linux, Windows, macOS, and iOS.
+
+The project should become easier to build, easier to understand, easier to warning-clean, and easier to port without changing existing functionality.
+
+## Guiding principle
+
+Measure behavior first. Refactor second.
+
+The current code is convoluted but functional. The first priority is to capture current behavior so later cleanup can be checked against known-good outputs.
+
+---
+
+## Phase 1: Baseline and documentation
+
+Status: not started
+
+Goals:
+
+- Document current build systems.
+- Document current supported targets.
+- Document known historical targets still present in the code.
+- Document generated artifacts.
+- Document high-risk source areas.
+- Capture warning counts.
+- Capture build logs.
+- Capture exported symbols.
+- Capture dist/install tree manifests.
+- Capture representative audio output from fixed input text.
+
+Rules:
+
+- Do not change engine code in this phase.
+- Do not remove macros.
+- Do not remove legacy target code.
+- Do not change build behavior.
+
+Suggested files:
+
+- `docs/modernization/BUILD_OVERVIEW.md`
+- `docs/modernization/RISK_AREAS.md`
+- `docs/modernization/MACRO_INVENTORY.md`
+- `docs/modernization/BASELINE_PROCEDURE.md`
+- `tests/golden/input/`
+
+---
+
+## Phase 2: Reproducible local verification
+
+Status: not started
+
+Goals:
+
+- Add scripts that make it easy to reproduce baseline checks locally.
+- Add scripts to capture build logs and warnings.
+- Add scripts to capture exported symbols.
+- Add scripts to capture generated audio files.
+- Add scripts to compare current output to baseline output.
+
+Rules:
+
+- Scripts may be added.
+- Avoid source changes unless required for scriptability.
+- Existing build systems must remain unchanged.
+
+Suggested files:
+
+- `tools/baseline/build_unix.sh`
+- `tools/baseline/capture_symbols.sh`
+- `tools/baseline/capture_dist_manifest.sh`
+- `tools/baseline/capture_audio.sh`
+- `tools/baseline/compare_audio.py`
+
+---
+
+## Phase 3: CI visibility
+
+Status: not started
+
+Goals:
+
+- Publish build logs as CI artifacts.
+- Publish warning logs as CI artifacts.
+- Publish dist tree manifests as CI artifacts.
+- Publish exported symbol lists as CI artifacts.
+- Optionally publish golden audio outputs as CI artifacts.
+
+Rules:
+
+- Do not make warnings fatal yet.
+- Do not remove existing CI jobs.
+- Do not remove VS6 or VS2022 jobs.
+- Do not change packaging layout.
+
+---
+
+## Phase 4: Macro inventory
+
+Status: not started
+
+Goals:
+
+- Classify important macros.
+- Identify which macros are active on Linux, Windows, macOS, and iOS.
+- Identify historical target macros.
+- Identify sound-critical feature macros.
+- Identify language-selection macros.
+- Identify build-system-only macros.
+
+Rules:
+
+- Do not delete macros during inventory.
+- Do not change default feature settings.
+- Do not change `dectalkf_klsyn.h` behavior.
+
+Macro categories:
+
+- current platform
+- current architecture
+- language selection
+- sound-critical feature
+- product feature
+- build-system define
+- historical target
+- unknown
+
+---
+
+## Phase 5: Low-risk warning cleanup
+
+Status: not started
+
+Goals:
+
+- Reduce warnings without changing behavior.
+- Work by warning category.
+- Keep changes small and reviewable.
+
+Low-risk categories:
+
+- missing prototypes
+- missing includes
+- duplicate declarations
+- unused parameters
+- obviously incorrect format strings
+- obvious local initialization
+- unreachable code caused by clearly inactive branches
+
+Rules:
+
+- Do not change arithmetic in synthesis code.
+- Do not change public headers unless required and explicitly reviewed.
+- Do not change struct layouts.
+- Do not change thread behavior.
+- Do not change audio behavior.
+- Do not change dictionary behavior.
+
+---
+
+## Phase 6: Platform abstraction scaffolding
+
+Status: not started
+
+Goals:
+
+- Start containing platform-specific behavior behind narrow interfaces.
+- Initially wrap existing behavior rather than rewriting it.
+- Reduce spread of raw `#ifdef WIN32`, `#ifdef __linux__`, and `#ifdef __APPLE__`.
+
+Candidate abstractions:
+
+- threads
+- mutexes
+- events
+- sleeping/time
+- filesystem paths
+- dynamic library exports
+- audio backends
+
+Suggested future files:
+
+- `src/platform/dt_platform.h`
+- `src/platform/dt_thread.h`
+- `src/platform/dt_thread_posix.c`
+- `src/platform/dt_thread_win32.c`
+- `src/platform/dt_event.h`
+- `src/platform/dt_mutex.h`
+- `src/platform/dt_time.h`
+- `src/platform/dt_filesystem.h`
+- `src/platform/dt_audio.h`
+
+Rules:
+
+- Do not rewrite working thread/audio code immediately.
+- Do not replace `opthread.c` in one step.
+- Do not split `linux_audio.c` until baseline audio checks exist.
+
+---
+
+## Phase 7: Side-by-side CMake build
+
+Status: not started
+
+Goals:
+
+- Add CMake as a modern build option.
+- Keep Autotools and Visual Studio projects intact.
+- Start with the core library and a minimal tool.
+- Generate `compile_commands.json` for analysis tooling.
+- Eventually support Linux, Windows, macOS, and iOS from one build description.
+
+Rules:
+
+- CMake must initially be side-by-side.
+- Do not remove Autotools.
+- Do not remove Visual Studio projects.
+- Do not change artifact names until compatibility is discussed.
+- Do not change source membership without documenting differences.
+
+---
+
+## Phase 8: Historical target quarantine
+
+Status: not started
+
+Goals:
+
+- Move unsupported historical target code behind explicit legacy options.
+- Reduce accidental interaction between current targets and historical branches.
+- Prepare for eventual removal if desired.
+
+Historical targets to investigate:
+
+- OSF/Tru64
+- VxWorks
+- MS-DOS
+- Windows CE
+- Solaris/SPARC
+- ARM7
+- MIPS
+- old PowerPC Mac
+- iPAQ Linux
+
+Rules:
+
+- Inventory first.
+- Quarantine second.
+- Delete only with explicit approval.
+
+---
+
+## Definition of done for each change
+
+A change is not complete unless the summary states:
+
+- what changed
+- why it changed
+- files changed
+- verification commands run
+- whether warnings changed
+- whether public exports changed
+- behavior risk level
+- known limitations
+
+Do not claim behavior preservation unless appropriate checks were run.
+
+---
+
+## Current immediate next step
+
+Create initial modernization documentation without changing engine code.
+
+Suggested first Codex task:
+
+Read the repository build files and create:
+
+- `docs/modernization/BUILD_OVERVIEW.md`
+- `docs/modernization/MACRO_INVENTORY_START.md`
+- `docs/modernization/RISK_AREAS.md`
+
+Do not edit source files.
+Do not change build files.
+Do not remove macros.

--- a/docs/modernization/BASELINE_PROCEDURE.md
+++ b/docs/modernization/BASELINE_PROCEDURE.md
@@ -1,0 +1,255 @@
+# Baseline Procedure
+
+This document describes the first preservation-focused baseline captures for
+DECtalk modernization. It is procedural documentation only. It does not add
+automation, change build files, change source files, or generate baseline
+artifacts by itself.
+
+## Goals
+
+Capture enough evidence to detect accidental changes in:
+
+- build behavior
+- compiler warnings
+- exported symbols
+- generated dictionaries
+- dist and install layouts
+- command-line tool behavior
+- deterministic text-to-speech output
+
+Baseline artifacts should be captured before source cleanup, macro cleanup,
+build-system replacement, dictionary changes, or audio/threading changes.
+
+## Non-Goals
+
+This procedure does not:
+
+- make warnings fatal
+- remove or rewrite macros
+- remove legacy build files
+- change supported targets
+- change generated dictionaries
+- change public headers or exported symbols
+- define pass/fail tolerances for audio comparison yet
+- replace any existing build system
+
+## Inputs
+
+The initial fixed input texts live under `tests/golden/input/`:
+
+- `basic.txt`
+- `commands.txt`
+- `numbers_dates.txt`
+- `languages.txt`
+
+Treat these files as stable stimuli. Do not edit them casually after baseline
+artifacts have been captured. If a future change needs new coverage, prefer
+adding a new input file or appending a clearly documented new section with a new
+baseline capture.
+
+## Build Log Capture
+
+Capture complete logs for each supported build path that can be run in the
+available environment.
+
+Unix-like build path:
+
+```sh
+cd src
+autoreconf -i
+./configure
+make
+```
+
+Windows build paths to capture separately:
+
+- `devops/vs2022/dt_buildall.bat`
+- `devops/vs2022/dt_copyfiles.bat`
+- `devops/vs6/dt_buildall.bat`
+- `devops/vs6/dt_copyfiles.bat`
+
+Record:
+
+- operating system and version
+- compiler and linker versions
+- environment variables that affect the build
+- exact commands
+- full stdout and stderr
+- exit status
+
+Do not normalize logs yet. Raw logs are useful because warning text and command
+lines can reveal platform differences.
+
+## Warning Log Capture
+
+For each build path, record compiler warnings separately from general build
+logs when practical.
+
+Useful summary fields:
+
+- total warning count
+- warning count by compiler warning code or message
+- source file associated with each warning
+- build target and language variant
+
+Warnings should be grouped by category before cleanup. Avoid random edits to
+silence individual warnings without a category-level plan.
+
+## Dist and Install Manifest Capture
+
+After a successful build and packaging/copy step, capture the output tree.
+
+Record:
+
+- relative file path
+- file type where useful
+- file size
+- file hash
+- executable bit or platform equivalent where useful
+
+Capture manifests separately for:
+
+- Unix `dist/`
+- VS2022 `dist/AMD64`
+- VS2022 `dist/IA32`
+- VS6 `dist/`
+
+The output layouts are not currently equivalent. Document differences before
+attempting to align them.
+
+## Dictionary Capture
+
+Generated dictionaries are behavior-critical artifacts.
+
+For each generated `dtalk_*.dic`, record:
+
+- build path that generated it
+- language or region
+- file size
+- cryptographic hash
+- dictionary compiler command line
+- dictionary compiler executable hash when practical
+
+Do not update checked-in generated dictionaries or dictionary generation rules
+as part of baseline capture unless a separate task explicitly approves that
+change.
+
+## Exported Symbol Capture
+
+Capture exported symbols for each generated shared library or DLL.
+
+Record separately by:
+
+- platform
+- architecture
+- build system
+- language variant
+- library or DLL name
+
+The symbol list is especially important before touching public headers,
+visibility macros, calling conventions, project files, or linker flags.
+
+## Command-Line Tool Capture
+
+Capture basic command-line behavior for built tools such as:
+
+- `say`
+- `speak` where scriptable
+- dictionary compiler tools
+- `windic` only where deterministic command-line behavior is available
+
+Record:
+
+- exact executable path
+- command line
+- stdout and stderr
+- exit status
+- generated files and hashes
+
+Prefer non-interactive invocations. Avoid tests that require live audio hardware
+when a wave, raw, null-audio, or log output mode is available.
+
+## Audio and Log Output Capture
+
+Use the fixed input files under `tests/golden/input/` to capture deterministic
+speech-related artifacts.
+
+Preferred artifacts:
+
+- WAV or raw audio output
+- text logs
+- phoneme logs where supported
+- syllable logs where supported
+
+For each output, record:
+
+- input file path and hash
+- build path
+- platform
+- architecture
+- language variant
+- command line
+- output file hash
+- audio duration
+- sample count
+- sample rate
+- RMS and peak values when available
+
+Do not compare audio by hash alone across different platforms until the expected
+cross-platform stability is understood. Hashes are still useful within the same
+platform and build path.
+
+## Suggested Capture Matrix
+
+Start with the smallest useful matrix:
+
+- Linux Autotools release build, all available language variants
+- macOS Autotools release build, all available language variants
+- VS2022 release build, current IA32 and AMD64 outputs
+- VS6 release build, all available language variants
+
+Expand only after the initial procedure is repeatable.
+
+## Artifact Storage
+
+This document does not choose a final storage layout. A future automation task
+should define a directory structure for captured artifacts.
+
+A useful future layout may separate:
+
+- raw logs
+- warning summaries
+- dist manifests
+- symbol lists
+- dictionary hashes
+- audio outputs
+- audio metrics
+- command output
+
+Avoid checking large generated artifacts into the repository until the storage
+policy is explicit.
+
+## Review Checklist
+
+Before using a baseline to approve cleanup, confirm:
+
+- the input files are unchanged
+- the build path is the same
+- the same language variant was used
+- generated dictionary hashes are known
+- exported symbols are known
+- dist manifests are known
+- audio/log artifacts are captured where relevant
+- any platform-specific differences are documented
+
+## Open Questions
+
+- Which output mode is most deterministic for Unix `say` across Linux and
+  macOS?
+- Which VS2022 command-line tool should be used for non-interactive audio or
+  log capture?
+- Which iOS build path should be used for baseline capture?
+- Are generated dictionaries expected to be byte-identical across Unix and
+  Windows build paths?
+- Which audio delta thresholds are acceptable for same-platform and
+  cross-platform comparisons?

--- a/docs/modernization/BASELINE_PROCEDURE.md
+++ b/docs/modernization/BASELINE_PROCEDURE.md
@@ -199,6 +199,32 @@ Do not compare audio by hash alone across different platforms until the expected
 cross-platform stability is understood. Hashes are still useful within the same
 platform and build path.
 
+After a successful build capture, use the local helper to capture file-output
+audio artifacts from a built `say` executable:
+
+```sh
+tools/baseline/capture_audio_outputs.sh SAY_EXE tests/golden/input OUT_DIR
+```
+
+The helper writes audio/file-output artifacts, per-input stdout and stderr logs,
+the exact commands used, a status file, and a manifest with sizes and hashes
+when a SHA-256 tool is available. It does not run a build and does not require
+live audio hardware when the supplied `say` supports file output.
+
+The initial helper uses this command shape for each input:
+
+```sh
+SAY_EXE -fi INPUT_FILE -fo OUT_DIR/audio/BASENAME.wav
+```
+
+Some checked-in `say` sources document different file-output options, such as
+`-w` with stdin. Treat command-line compatibility as part of the baseline
+evidence and record any failures in the run notes.
+
+Audio capture outputs are local baseline artifacts. Do not commit output under
+`baseline-runs/` or any other generated artifact directory unless explicitly
+approved.
+
 ## Suggested Capture Matrix
 
 Start with the smallest useful matrix:

--- a/docs/modernization/BASELINE_PROCEDURE.md
+++ b/docs/modernization/BASELINE_PROCEDURE.md
@@ -225,6 +225,27 @@ Audio capture outputs are local baseline artifacts. Do not commit output under
 `baseline-runs/` or any other generated artifact directory unless explicitly
 approved.
 
+After capturing a second candidate audio baseline, compare it against an older
+capture with:
+
+```sh
+python3 tools/baseline/compare_audio_outputs.py \
+  --baseline OLD_CAPTURE_DIR \
+  --candidate NEW_CAPTURE_DIR \
+  --output REPORT.md
+```
+
+The comparison helper checks expected artifacts by name, compares file sizes and
+SHA-256 hashes using Python, and records WAV metadata differences when both
+files are valid WAV files. Exact byte-for-byte equality is the strongest local
+signal for same-platform repeatability. Metadata differences are still useful
+for diagnosis because they can show sample rate, sample width, channel count,
+frame count, or duration changes even before sample-level comparison exists.
+
+Do not treat a passing comparison report as a complete behavior-preservation
+proof. It is one baseline signal alongside build logs, warning summaries, dist
+manifests, dictionaries, exported symbols, and command output.
+
 ## Suggested Capture Matrix
 
 Start with the smallest useful matrix:

--- a/docs/modernization/BASELINE_RUNS.md
+++ b/docs/modernization/BASELINE_RUNS.md
@@ -73,6 +73,93 @@ code, and syntax/preprocessor.
 - `baseline-runs/` remains local generated output and should not be committed
   unless explicitly approved.
 
+## unix-after-liceninc-001
+
+- Capture date: 2026-05-15T10:50:40Z through 2026-05-15T10:50:43Z.
+- Local output directory inspected:
+  `baseline-runs/unix-after-liceninc-001/`.
+- Command used:
+  `tools/baseline/capture_unix_build.sh baseline-runs/unix-after-liceninc-001`.
+- Before baseline inspected: `baseline-runs/unix-001/`.
+- Source file changed for this cleanup: `src/licunix/src/liceninc.c`.
+- Warning targeted:
+  `liceninc.c:71:48: warning: '%s' directive writing up to 999 bytes into a region of size 991 [-Wformat-overflow=]`.
+- Cleanup shape: the `licenses:` line generation was changed from unbounded
+  `sprintf(line,"licenses:%s\n",encrypt)` to checked `snprintf` bounded by
+  `sizeof(line)`.
+- Git branch at capture: `cleanup`.
+- Captured git status showed the intended `src/licunix/src/liceninc.c` source
+  edit and untracked local `baseline-runs/` output.
+
+### Captured Steps
+
+| Step | Command | Exit Code | Log |
+| --- | --- | ---: | --- |
+| Git state | `tools/baseline/capture_git_state.sh baseline-runs/unix-after-liceninc-001/git` | 0 | `baseline-runs/unix-after-liceninc-001/git/` |
+| Autoreconf | `autoreconf -i` | 0 | `baseline-runs/unix-after-liceninc-001/autoreconf.log` |
+| Configure | `./configure` | 0 | `baseline-runs/unix-after-liceninc-001/configure.log` |
+| Make | `make` | 0 | `baseline-runs/unix-after-liceninc-001/make.log` |
+| Warning summary | `python3 tools/baseline/summarize_warnings.py ...` | 0 | `baseline-runs/unix-after-liceninc-001/warnings-summary.md` |
+
+The overall captured final exit code was 0.
+
+### Cleanup Result
+
+The before baseline `baseline-runs/unix-001/make.log` contained three
+`[-Wformat-overflow=]` warning lines for `liceninc.c:71`.
+
+The after baseline `baseline-runs/unix-after-liceninc-001/make.log` contained
+no `[-Wformat-overflow=]` or `liceninc.c:71` warnings. The target warning
+disappeared in this local capture.
+
+The remaining `liceninc.c` warning in the after capture was the existing
+`tmpnam` linker warning at `liceninc.c:44`. That warning was intentionally not
+addressed in this narrow cleanup.
+
+### Warning Count Notes
+
+| Capture | Total Warning-Like Lines | `integer conversion / truncation` | `uncategorized` |
+| --- | ---: | ---: | ---: |
+| `baseline-runs/unix-001/` | 1,837 | 3 | 23 |
+| `baseline-runs/unix-after-liceninc-001/` | 2 | 0 | 2 |
+
+The after `make.log` was much shorter than the original baseline log
+(`868` lines versus `9,203` lines), and appears to reflect an incremental
+rebuild. Treat the result as evidence that the targeted `liceninc.c`
+`[-Wformat-overflow=]` warning disappeared, not as proof of broad whole-repo
+warning reduction.
+
+### Verification Commands Used
+
+- `git diff -- src/licunix/src/liceninc.c`
+- `git diff --check`
+- `tools/baseline/capture_unix_build.sh baseline-runs/unix-after-liceninc-001`
+- inspection of `baseline-runs/unix-001/warnings-summary.md`
+- inspection of `baseline-runs/unix-001/make.log`
+- inspection of `baseline-runs/unix-after-liceninc-001/warnings-summary.md`
+- inspection of `baseline-runs/unix-after-liceninc-001/make.log`
+
+### Intentionally Not Changed
+
+- No synthesis, audio, threading, dictionary, public API, or build files were
+  changed.
+- `src/license/LICENINC/liceninc.c` was not changed.
+- The `tmpnam` warning in `src/licunix/src/liceninc.c` was not changed.
+- No broad warning cleanup was attempted.
+- No macros were removed or simplified.
+- `baseline-runs/` remains local generated output and should not be committed
+  unless explicitly approved.
+
+### Notable Limitations
+
+- This capture does not prove speech, API, dictionary, packaging, exported
+  symbol, or runtime behavior preservation.
+- No audio output capture or audio comparison was run after this source cleanup.
+- No exported symbol inventory, dictionary hashes, or dist manifest were
+  compared for this cleanup.
+- Because the after build appears incremental, warning totals are not directly
+  comparable to the original full baseline.
+
 ## audio-001
 
 - Capture date: 2026-05-15T10:11:24Z.

--- a/docs/modernization/BASELINE_RUNS.md
+++ b/docs/modernization/BASELINE_RUNS.md
@@ -72,3 +72,67 @@ code, and syntax/preprocessor.
   the final exit code.
 - `baseline-runs/` remains local generated output and should not be committed
   unless explicitly approved.
+
+## audio-001
+
+- Capture date: 2026-05-15T10:11:24Z.
+- Local output directory inspected: `baseline-runs/audio-001/`.
+- Command used:
+  `tools/baseline/capture_audio_outputs.sh dist/say tests/golden/input baseline-runs/audio-001`.
+- `say` executable: `dist/say`.
+- Golden input directory: `tests/golden/input`.
+- Command template: `SAY_EXE -fi INPUT_FILE -fo OUT_WAV`.
+
+### Captured Inputs
+
+| Input | Exit Code | Result | Audio Output |
+| --- | ---: | --- | --- |
+| `tests/golden/input/basic.txt` | 0 | success | `baseline-runs/audio-001/audio/basic.wav` |
+| `tests/golden/input/commands.txt` | 0 | success | `baseline-runs/audio-001/audio/commands.wav` |
+| `tests/golden/input/languages.txt` | 0 | success | `baseline-runs/audio-001/audio/languages.wav` |
+| `tests/golden/input/numbers_dates.txt` | 0 | success | `baseline-runs/audio-001/audio/numbers_dates.wav` |
+
+### Captured Logs
+
+Stdout and stderr were captured under `baseline-runs/audio-001/logs/`.
+
+Observed log files:
+
+- `basic.stdout.txt` and `basic.stderr.txt`
+- `commands.stdout.txt` and `commands.stderr.txt`
+- `languages.stdout.txt` and `languages.stderr.txt`
+- `numbers_dates.stdout.txt` and `numbers_dates.stderr.txt`
+
+All observed stdout and stderr log files were empty in this capture.
+
+### Manifest And Hashes
+
+The run generated:
+
+- `baseline-runs/audio-001/audio-manifest.txt`
+- `baseline-runs/audio-001/audio-sha256.txt`
+
+`audio-sha256.txt` records SHA-256 hashes generated with `sha256sum`.
+
+Recorded audio output sizes:
+
+| Audio Output | Size |
+| --- | ---: |
+| `baseline-runs/audio-001/audio/basic.wav` | 742,136 bytes |
+| `baseline-runs/audio-001/audio/commands.wav` | 786,156 bytes |
+| `baseline-runs/audio-001/audio/languages.wav` | 859,570 bytes |
+| `baseline-runs/audio-001/audio/numbers_dates.wav` | 1,675,502 bytes |
+
+### Notable Limitations
+
+- This capture does not prove speech, API, dictionary, packaging, exported
+  symbol, or runtime behavior preservation.
+- No audio comparison was performed.
+- No audio metrics such as duration, sample count, sample rate, RMS, or peak
+  values were computed.
+- `languages.txt` was run as one input through the single `dist/say`
+  executable, not split by language-specific build or voice.
+- The capture uses the helper's `-fi`/`-fo` command shape; other `say` variants
+  may document different file-output options.
+- Audio outputs remain local generated artifacts. Do not commit
+  `baseline-runs/` unless explicitly approved.

--- a/docs/modernization/BASELINE_RUNS.md
+++ b/docs/modernization/BASELINE_RUNS.md
@@ -1,0 +1,74 @@
+# Baseline Runs
+
+This file records summaries of local baseline captures. These notes are for
+modernization planning only and do not prove behavior preservation.
+
+Local output under `baseline-runs/` is generated evidence and should not be
+committed unless explicitly approved.
+
+## unix-001
+
+- Capture date: 2026-05-15T09:53:07Z through 2026-05-15T09:53:17Z.
+- Local output directory inspected: `baseline-runs/unix-001/`.
+- Command used: `tools/baseline/capture_unix_build.sh baseline-runs/unix-001`.
+- Git branch at capture: `cleanup`.
+- Git HEAD at capture: `d890de1188b046e06797cd729d50d10837d7c45b`
+  (`Add Unix build log capture helper`).
+
+### Platform And Toolchain Notes
+
+- `configure` reported build, host, and target as `x86_64-pc-linux-gnu`.
+- `configure` used `gcc`.
+- Captured install paths included `6.6.114.1-microsoft-standard-WSL2`, so this
+  run appears to have been captured from a Linux environment on WSL2.
+- Optional dependency probes reported `gtk+-2.0`, `libpulse-simple`, and `alsa`
+  as unavailable.
+- `iconv` was available.
+
+### Captured Steps
+
+| Step | Command | Exit Code | Log |
+| --- | --- | --- | --- |
+| Git state | `tools/baseline/capture_git_state.sh baseline-runs/unix-001/git` | 0 | `baseline-runs/unix-001/git/` |
+| Autoreconf | `autoreconf -i` | 0 | `baseline-runs/unix-001/autoreconf.log` |
+| Configure | `./configure` | 0 | `baseline-runs/unix-001/configure.log` |
+| Make | `make` | 0 | `baseline-runs/unix-001/make.log` |
+| Warning summary | `python3 tools/baseline/summarize_warnings.py ...` | 0 | `baseline-runs/unix-001/warnings-summary.md` |
+
+The overall captured final exit code was 0.
+
+### Warning Summary
+
+`baseline-runs/unix-001/warnings-summary.md` was generated successfully.
+
+The warning summarizer found 1,837 warning-like lines:
+
+| Category | Count |
+| --- | ---: |
+| unknown compiler warning | 1,669 |
+| uninitialized variable | 112 |
+| format string mismatch | 24 |
+| uncategorized | 23 |
+| unused variable/function/parameter | 6 |
+| integer conversion / truncation | 3 |
+
+Categories with zero matches included missing prototype / implicit declaration,
+incompatible pointer type, pointer/integer conversion, signed/unsigned
+comparison, deprecated declaration/API, macro redefinition, unreachable/dead
+code, and syntax/preprocessor.
+
+### Notable Limitations
+
+- This capture does not prove speech, API, dictionary, packaging, exported
+  symbol, or runtime behavior preservation.
+- No audio outputs were generated or compared.
+- No generated dictionary hashes were captured in this run.
+- No exported symbol inventory was captured in this run.
+- No installed/dist manifest was captured in this run.
+- Warning categorization is heuristic, and most warning-like lines were grouped
+  under `unknown compiler warning`.
+- `make` exited 0, but `make.log` included ignored install errors for missing
+  `gspeak` and `windic` sample artifacts. The log should be reviewed alongside
+  the final exit code.
+- `baseline-runs/` remains local generated output and should not be committed
+  unless explicitly approved.

--- a/docs/modernization/BASELINE_RUNS.md
+++ b/docs/modernization/BASELINE_RUNS.md
@@ -136,3 +136,51 @@ Recorded audio output sizes:
   may document different file-output options.
 - Audio outputs remain local generated artifacts. Do not commit
   `baseline-runs/` unless explicitly approved.
+
+## audio-self-compare
+
+- Comparison date: 2026-05-15T10:24:13Z.
+- Local report file inspected: `baseline-runs/audio-self-compare.md`.
+- Command used:
+  `python3 tools/baseline/compare_audio_outputs.py --baseline baseline-runs/audio-001 --candidate baseline-runs/audio-001 --output baseline-runs/audio-self-compare.md`.
+- Baseline directory: `baseline-runs/audio-001`.
+- Candidate directory: `baseline-runs/audio-001`.
+- Result: `PASS`.
+
+### Smoke-Test Summary
+
+| Metric | Count |
+| --- | ---: |
+| Baseline artifacts | 4 |
+| Candidate artifacts | 4 |
+| Compared artifacts | 4 |
+| Exact matches | 4 |
+| Missing files | 0 |
+| Extra files | 0 |
+| Differing files | 0 |
+| Unreadable files | 0 |
+| WAV metadata differences | 0 |
+| WAV metadata errors | 0 |
+
+The report does not record the shell exit code directly. The comparison helper
+is documented to exit 0 only when all compared artifacts match exactly, and this
+self-compare report recorded `PASS`.
+
+### What This Proves
+
+- The comparison helper can read an existing `capture_audio_outputs.sh` output
+  directory.
+- The helper can compare the four captured audio artifacts by name.
+- The helper can compute exact file matches and parse WAV metadata for the
+  current `audio-001` files.
+- The helper can write a Markdown comparison report.
+
+### What This Does Not Prove
+
+- This self-compare does not prove speech, API, dictionary, packaging, exported
+  symbol, or runtime behavior preservation.
+- It does not compare two independent captures.
+- It does not validate cross-platform repeatability.
+- It does not compute RMS, peak, perceptual difference, or sample-level deltas.
+- `baseline-runs/` remains local generated output and should not be committed
+  unless explicitly approved.

--- a/docs/modernization/BUILD_OVERVIEW.md
+++ b/docs/modernization/BUILD_OVERVIEW.md
@@ -1,0 +1,217 @@
+# DECtalk Build Overview
+
+This document records the build paths observed at the start of modernization.
+It is descriptive only. It does not propose removing, replacing, or changing any
+existing build system.
+
+## Scope
+
+Modernization work should preserve the existing build behavior until replacement
+or cleanup work has parity evidence. The currently intended targets are Linux,
+Windows, macOS, and iOS, but the repository also contains historical build paths
+and platform branches that should remain intact during baseline documentation.
+
+## Top-Level Layout
+
+- `src/` contains the main DECtalk source tree and most build files.
+- `src/configure.ac` drives the Unix-like Autotools configuration.
+- `src/Makefile.in` is the top-level Unix Makefile template.
+- `src/Makefile.sub.in` coordinates lower-level Unix builds.
+- `src/dapi/src/` contains the main API/library sources and several project
+  files for Windows builds.
+- `devops/` contains CI-oriented Windows build and copy scripts.
+- `.github/workflows/build.yml` defines current CI build jobs.
+- `ports/emscripten/` exists as a separate port-related area.
+
+## Unix-Like Build Path
+
+The Unix-like build uses Autotools and Make from `src/`.
+
+Observed CI sequence:
+
+```sh
+cd src
+autoreconf -i
+./configure
+make
+```
+
+Important files:
+
+- `src/configure.ac`
+- `src/Makefile.in`
+- `src/Makefile.sub.in`
+- `src/dapi/src/Makefile.in`
+- `src/dapi/src/Makefile.sub.in`
+- `src/dapi/src/*/Makefile.in`
+- `src/dtalkml/src/Makefile.in`
+- `src/samplosf/src/*/Makefile`
+- `src/licunix/src/Makefile.in`
+- `src/udicunix/src/Makefile.in`
+
+`src/configure.ac` generates Makefiles for:
+
+- `Makefile`
+- `Makefile.sub`
+- `dapi/src/Makefile`
+- `dapi/src/Makefile.sub`
+- `dapi/src/api/Makefile`
+- `dapi/src/cmd/Makefile`
+- `dapi/src/dic/Makefile`
+- `dapi/src/kernel/Makefile`
+- `dapi/src/lts/Makefile`
+- `dapi/src/nt/Makefile`
+- `dapi/src/osf/Makefile`
+- `dapi/src/ph/Makefile`
+- `dapi/src/vtm/Makefile`
+- `dapi/src/hlsyn/Makefile`
+- `dtalkml/src/Makefile`
+- `samplosf/src/speak/Makefile`
+- `samplosf/src/windict/Makefile`
+- `samplosf/src/dtsamples/Makefile`
+- `licunix/src/Makefile`
+- `udicunix/src/Makefile`
+
+The top-level Unix Makefile builds language variants through targets such as:
+
+- `english_release`
+- `uk_release`
+- `spanish_release`
+- `german_release`
+- `latin_american_release`
+- `french_release`
+
+The Unix `all` target installs into `../dist` by default. The install target
+copies libraries, dictionary tools, generated dictionaries, sample programs,
+headers, documentation, bitmaps, and a generated `DECtalk.conf`.
+
+## Unix Build Defines and Platform Branches
+
+`src/configure.ac` sets core compile defines including:
+
+- `LTSSIM`
+- `TTSSIM`
+- `ANSI`
+- `BLD_DECTALK_DLL`
+- `$(LANGUAGE)`
+- `DECTALK_INSTALL_PREFIX`
+- `ACCESS32`
+- `TYPING_MODE`
+
+Observed platform-specific branches include:
+
+- Linux: `_REENTRANT`, `NOMME`
+- macOS: `_REENTRANT`, `NOMME`, optional universal binary flags
+- Solaris/SPARC: `_SPARC_SOLARIS_`, `_BIGENDIAN_`
+- old PowerPC Mac: `_APPLE_MAC_`, `_BIGENDIAN_`
+- iPAQ Linux: `__ipaq__`, custom cross compiler paths
+
+Audio-related configuration currently probes PulseAudio and ALSA on Linux and
+adds Apple frameworks on macOS. These details are behavior-relevant and should
+be captured before any build-system cleanup.
+
+## Windows Build Paths
+
+The repository contains both modern Visual Studio project files and legacy
+Visual Studio 6 project files.
+
+Observed VS2022 wrapper:
+
+- `devops/vs2022/dt_buildall.bat`
+- `devops/vs2022/dt_copyfiles.bat`
+- `src/DECtalk.sln`
+- `src/dapi/src/DECtalk API.vcxproj`
+- `src/dapi/src/Internal Dictionary Compiler.vcxproj`
+- `src/samples/speak/Sample Speak Window.vcxproj`
+
+The VS2022 wrapper currently builds:
+
+- `Release - ENGLISH_US` for `AMD64`
+- `Release - ENGLISH_US` for `IA32`
+
+The VS2022 copy script creates separate `dist/AMD64` and `dist/IA32` trees and
+copies the US DECtalk DLL, dictionary compiler, generated US dictionary, and
+sample speak executable.
+
+Observed VS6 wrapper:
+
+- `devops/vs6/dt_buildall.bat`
+- `devops/vs6/dt_copyfiles.bat`
+
+The VS6 wrapper builds multiple language variants for the DECtalk API and
+dictionary compiler:
+
+- US English
+- UK English
+- Spanish
+- German
+- Latin American
+- French
+
+The VS6 copy script creates a single `dist/` tree with language-specific DLLs,
+dictionary compiler tools, generated dictionaries, and sample executables.
+
+## Legacy and Historical Build Files
+
+The tree contains many historical Windows and platform-specific build artifacts,
+including:
+
+- Visual Studio 6 `.dsp` and `.dsw` files
+- Windows CE build files and scripts
+- installation and kitting batch scripts
+- OSF documentation and sample Makefiles
+- hardware and embedded-oriented directories
+
+These files may be obsolete for current targets, but they should not be deleted
+or rewritten during initial modernization. They are part of the historical build
+surface and may still encode source membership, macro choices, or packaging
+behavior.
+
+## CI Build Jobs
+
+`.github/workflows/build.yml` currently defines jobs for:
+
+- Ubuntu latest using Autotools and Make
+- macOS 13 using Autotools and Make
+- Visual Studio 6 on a self-hosted Windows runner
+- Visual Studio 2022 on Windows 2022
+
+CI publishes `dist/` artifacts for each platform path. The workflow currently
+targets the `develop` branch for push and pull request triggers.
+
+## Generated and Packaged Artifacts
+
+Important generated or packaged outputs include:
+
+- DECtalk shared libraries or DLLs
+- language-specific `dtalk_*.dic` dictionaries
+- dictionary compiler binaries
+- `dtalkml` library output
+- sample tools such as `say`, `speak`, `windic`, `dtmemory`, `aclock`, and
+  `tunecheck`
+- installed headers under `include/dtk`
+- documentation and bitmaps in the install tree
+- generated `DECtalk.conf`
+
+Changes that affect these outputs need baseline manifests before cleanup.
+
+## Open Questions
+
+- Which source files differ between Unix, VS2022, and VS6 builds?
+- Which generated dictionaries are byte-stable across platforms?
+- Which exported symbols are expected for each library or DLL?
+- Which historical build files are still used by users outside CI?
+- What is the intended iOS build path, and does it share the macOS Autotools
+  path or require separate project files?
+
+## Recommended Baseline Captures
+
+Before changing build logic, capture:
+
+- full build logs
+- warning logs
+- generated dictionary hashes
+- exported symbol lists
+- dist/install tree manifests
+- representative command-line tool output
+- deterministic WAV or raw audio output from fixed input text

--- a/docs/modernization/MACRO_INVENTORY_START.md
+++ b/docs/modernization/MACRO_INVENTORY_START.md
@@ -1,0 +1,236 @@
+# Macro Inventory Start
+
+This is a starting point for a preservation-first macro inventory. It records
+visible macro groups and likely classifications. It is not a cleanup plan, and
+none of these macros should be removed or simplified without baseline evidence.
+
+## Classification Categories
+
+Use these categories from the modernization policy:
+
+- current platform
+- current architecture
+- language selection
+- sound-critical feature
+- product feature
+- build-system define
+- historical target
+- unknown
+
+When a macro fits multiple categories, document the ambiguity instead of forcing
+one answer too early.
+
+## Build-System Defines
+
+`src/configure.ac` provides the main Unix-like build defines. Common observed
+defines include:
+
+- `LTSSIM`
+- `TTSSIM`
+- `ANSI`
+- `BLD_DECTALK_DLL`
+- `DECTALK_INSTALL_PREFIX`
+- `ACCESS32`
+- `TYPING_MODE`
+- `NOMME`
+- `_REENTRANT`
+
+The `LANGUAGE` make variable expands to language and regional defines. Observed
+Unix release targets pass combinations such as:
+
+- `ENGLISH`, `ENGLISH_US`, `ACNA`
+- `ENGLISH`, `ENGLISH_UK`
+- `SPANISH`, `SPANISH_SP`
+- `SPANISH`, `SPANISH_LA`
+- `GERMAN`
+- `FRENCH`
+
+Windows project files and batch wrappers also define language, platform, and
+configuration-specific values. These need a separate pass because the VS2022 and
+VS6 build surfaces differ.
+
+## Current Platform Markers
+
+Likely current platform macros:
+
+- `__linux__`
+- `WIN32`
+- `_WIN32`
+- `_WIN64`
+- `__APPLE__`
+- `__EMSCRIPTEN__`
+
+Notes:
+
+- `__APPLE__` appears in current Unix-like source branches and configure logic.
+- macOS currently uses Autotools in CI.
+- iOS support needs explicit documentation. The repository has Apple branches,
+  but the exact iOS build path was not identified in this initial pass.
+- `__EMSCRIPTEN__` appears in public API and portability headers, but it is not
+  listed as a current intended target in `AGENTS.md`.
+
+## Historical Target Markers
+
+Historical or likely historical target macros and markers include:
+
+- `__osf__`
+- `OSF`
+- `VXWORKS`
+- `_SPARC_SOLARIS_`
+- `_BIGENDIAN_`
+- `UNDER_CE`
+- `_WIN32_WCE`
+- `_WIN32_WCE_EMULATION`
+- `MSDOS`
+- `ARM7`
+- `EPSON_ARM7`
+- `ARM7_NOSWI`
+- `MIPS`
+- `_MIPS_`
+- `SH3`
+- `_SH3_`
+- `__ipaq__`
+- `_APPLE_MAC_`
+- `UNIX_AND_MIPS`
+
+These should be inventoried and classified before any quarantine or removal is
+considered. Some historical branches may still interact with current source
+membership or public headers.
+
+## Language Selection Macros
+
+Language and region macros are behavior-critical because they affect dictionaries,
+phoneme rules, parser behavior, voice data, and generated artifacts.
+
+Observed examples:
+
+- `ENGLISH`
+- `ENGLISH_US`
+- `ENGLISH_UK`
+- `SPANISH`
+- `SPANISH_SP`
+- `SPANISH_LA`
+- `GERMAN`
+- `FRENCH`
+- `SWAHILI`
+- `ACNA`
+- `NWSNOAA`
+- `NWS_LA`
+
+Do not normalize or rename these until dictionary and audio baselines exist.
+
+## Sound-Critical Feature Macros
+
+The highest-risk macro definitions appear in:
+
+- `src/dectalkf_klsyn.h`
+- `src/dectalkf_hlsyn.h`
+- `src/dapi/src/api/ttsapi.c`
+- `src/dapi/src/api/tts.h`
+- `src/dapi/src/include/port.h`
+
+Examples that should be treated as sound-critical or timing-critical:
+
+- `NEW_BINARY_PARSER`
+- `GERMAN_COMPOUND_NOUNS`
+- `HLSYN`
+- `ACCESS32`
+- `TYPING_MODE`
+- `SLOWTALK`
+- `NEW_PHONES`
+- `FP_VTM`
+- `AD_BASE`
+- `SINGLE_THREADED`
+- `NEW_INTONATION`
+- `PARSER_HACK_FOR_OLD_SONGS`
+- `OLD_INTONATION_AND_TIMING`
+- `VTM1`
+- `PC_SAMPLE_RATE`
+- `VOICE_ROM_DECTALK_1996M_43F`
+- `VOICE_ROM_1997`
+- `VOICE_ROM_1996`
+- `VOICE_ROM_DECTALK_41`
+- `VOICE_ROM_DECTALK_43`
+- `VOICE_ROM_DTC_03_03JAN89`
+- `OLD_SETTAR`
+- `SOFTWARE_VOLUME`
+
+The HLSYN configuration header has additional macros such as:
+
+- `UPGRADES1999`
+- `NEW_VOCAL_TRACT`
+- `NEW_VTM`
+- `NEW_TILT`
+- `NEW_NOISE`
+- `CHANGES_AFTER_V43`
+- `VOICE_ROM_BETA5`
+
+These can affect speech output. They should be documented with current defaults
+and baseline audio before any edits.
+
+## Product and Integration Macros
+
+Likely product, integration, or packaging macros include:
+
+- `SAPI_MULTI_LANGUAGE_SUPPORT`
+- `SAPI_GROUP_F_INTERFACES`
+- `SAPI_GROUP_H_TIMING`
+- `SAPI5DECTALK`
+- `OLEDECTALK`
+- `CUP28PROJECT`
+- `ACI_LICENSE`
+- `DTALK50`
+- `DTALK_50`
+- `LDS_BUILD`
+- `STATIC_BUILD`
+- `ACCESS_SOLUTIONS`
+- `DEMO`
+- `DEMO_NOISE`
+- `PHEDIT2`
+- `API_DEBUG`
+- `PRINTFDEBUG`
+
+Some of these may affect exported interfaces, licensing paths, or integration
+behavior. They should be classified from build files and call sites before any
+cleanup.
+
+## Portability and Type Macros
+
+Portability headers emulate platform types and APIs. Important areas include:
+
+- `src/dapi/src/include/port.h`
+- `src/dapi/src/osf/dtmmedefs.h`
+- `src/dapi/src/osf/dtmmiodefs.h`
+- `src/dapi/src/api/ttsapi.h`
+- `src/dapi/src/api/tts.h`
+
+Observed themes:
+
+- Windows type compatibility on Unix-like platforms
+- endian handling
+- audio format constants
+- file and multimedia compatibility definitions
+- thread and event compatibility wrappers
+
+These definitions may look mechanical, but they can affect public API layout and
+binary compatibility.
+
+## Initial Inventory Commands
+
+Useful read-only commands for the next pass:
+
+```sh
+rg -n "^#\\s*(if|ifdef|ifndef|elif|define)" src/dectalkf*.h src/dapi/src
+rg -n "WIN32|__linux__|__APPLE__|VXWORKS|__osf__|UNDER_CE|ARM7|MSDOS" src
+rg -n "ENGLISH|SPANISH|GERMAN|FRENCH|SWAHILI|ACNA" src
+rg -n "HLSYN|VTM|INTONATION|VOICE_ROM|SAMPLE_RATE|TYPING_MODE" src
+```
+
+## Next Steps
+
+- Build a table of macros with file, line, category, owner area, and observed
+  build source.
+- Separate current target macros from historical target macros.
+- Record which macros are defined by Autotools, VS2022, VS6, and source headers.
+- Mark sound-critical macros before any warning cleanup touches nearby code.
+- Capture baselines before changing any macro defaults.

--- a/docs/modernization/RISK_AREAS.md
+++ b/docs/modernization/RISK_AREAS.md
@@ -1,0 +1,239 @@
+# Modernization Risk Areas
+
+This document identifies areas that need extra care during DECtalk modernization.
+It is a guide for preservation-first work, not a list of files to refactor.
+
+## Core Principle
+
+Behavior preservation is more important than cleanup. Do not claim behavior is
+preserved unless the relevant build, dictionary, API, or audio checks were run.
+
+## Highest-Risk Files
+
+Treat these files as behavior-critical:
+
+- `src/dectalkf.h`
+- `src/dectalkf_klsyn.h`
+- `src/dectalkf_hlsyn.h`
+- `src/dapi/src/api/ttsapi.h`
+- `src/dapi/src/api/tts.h`
+- `src/dapi/src/api/ttsapi.c`
+- `src/dapi/src/api/init.c`
+- `src/dapi/src/nt/opthread.c`
+- `src/dapi/src/nt/linux_audio.c`
+
+Reasons:
+
+- public API definitions
+- exported symbols and calling conventions
+- startup and initialization behavior
+- compile-time feature selection
+- voice ROM and synthesizer configuration
+- threading, queue, event, pipe, callback, and audio behavior
+
+## Highest-Risk Directories
+
+Treat these directories as behavior-critical:
+
+- `src/dapi/src/lts`
+- `src/dapi/src/ph`
+- `src/dapi/src/vtm`
+- `src/dapi/src/hlsyn`
+- `src/dapi/src/dic`
+- `src/dapi/src/api`
+- `src/dapi/src/nt`
+- `src/dapi/src/include`
+
+These directories contain language processing, phoneme generation, synthesizer
+logic, dictionary handling, public API definitions, threading, and platform
+compatibility code.
+
+## Speech Output Risk
+
+Avoid unverified changes in areas that can affect:
+
+- phoneme output
+- parser behavior
+- intonation and timing
+- default voice selection
+- voice ROM selection
+- sample rate
+- vocal tract model behavior
+- software volume behavior
+- language-specific rule selection
+
+Especially risky files include the `dectalkf_*` configuration headers and source
+under `lts`, `ph`, `vtm`, and `hlsyn`.
+
+Recommended evidence before changes:
+
+- fixed-input audio output
+- file hashes for WAV or raw outputs
+- sample counts
+- RMS and peak deltas
+- phoneme or log output where available
+
+## Dictionary Risk
+
+Dictionary behavior is high risk. Do not change dictionary source, generation,
+loading, lookup, compression, file names, install paths, or generated `.dic`
+files without explicit baseline evidence.
+
+Important areas:
+
+- `src/dapi/src/dic`
+- dictionary compiler project files
+- dictionary build rules in Unix Makefiles
+- dictionary build steps in VS6 scripts
+- generated `dtalk_*.dic` files
+- install and copy scripts that package dictionaries
+
+Recommended evidence before changes:
+
+- generated dictionary hashes
+- dictionary compiler command lines
+- dist tree manifests
+- representative lookup or synthesis output
+
+## Public API and Binary Compatibility Risk
+
+Public headers and exported symbols must remain stable unless a task explicitly
+approves an API change.
+
+Important files:
+
+- `src/dapi/src/api/ttsapi.h`
+- `src/dapi/src/api/tts.h`
+- `src/dapi/src/osf/dtmmedefs.h`
+- installed headers under `include/dtk`
+
+Risky changes include:
+
+- changing public function signatures
+- changing exported symbol names
+- changing typedefs or struct layout
+- changing callback signatures
+- changing DLL or shared-library names
+- changing audio format constants
+- changing conditional visibility macros
+
+Recommended evidence before changes:
+
+- exported symbol lists
+- installed header manifests
+- ABI-oriented review of structs and callbacks
+- downstream sample build checks
+
+## Threading, Timing, and Audio Risk
+
+Threading and audio code is behavior-critical because small changes can affect
+timing, callbacks, synchronization, and audio output.
+
+Important files:
+
+- `src/dapi/src/api/ttsapi.c`
+- `src/dapi/src/nt/opthread.c`
+- `src/dapi/src/nt/linux_audio.c`
+- `src/dapi/src/nt/pipe.c`
+- `src/dapi/src/nt/spc.c`
+- `src/dapi/src/vtm/sync.c`
+- `src/dapi/src/vtm/playtone.c`
+
+Risky changes include:
+
+- thread function signature changes
+- queue or pipe size changes
+- sleep interval changes
+- callback timing changes
+- audio backend selection changes
+- synchronization reset behavior changes
+- `volatile` or concurrency cleanup without focused tests
+
+Recommended evidence before changes:
+
+- deterministic no-live-audio output mode where possible
+- callback sequence logs
+- audio sample counts
+- deadlock or timeout-focused tests
+- platform-specific build logs
+
+## Build and Packaging Risk
+
+The repository has several build paths that are not equivalent. Preserve them
+until parity is documented.
+
+Important areas:
+
+- `src/configure.ac`
+- `src/Makefile.in`
+- `src/Makefile.sub.in`
+- `src/dapi/src/Makefile.in`
+- `src/dapi/src/Makefile.sub.in`
+- `src/DECtalk.sln`
+- `src/dapi/src/*.vcxproj`
+- legacy `.dsp` and `.dsw` files
+- `devops/vs2022`
+- `devops/vs6`
+- `.github/workflows/build.yml`
+- installation and kitting scripts
+
+Risky changes include:
+
+- changing source membership
+- changing output names
+- changing install layout
+- changing language variant coverage
+- replacing build systems before parity exists
+- changing generated dictionary locations
+
+Recommended evidence before changes:
+
+- build logs
+- warning logs
+- dist/install tree manifests
+- generated artifact hashes
+- source membership comparisons between build systems
+
+## Macro Cleanup Risk
+
+Preprocessor conditionals are deeply tied to platform, language, product, and
+sound behavior. Do not remove or simplify macros casually.
+
+High-risk macro groups include:
+
+- language selection macros
+- current platform macros
+- historical target macros that still affect shared headers
+- voice ROM and synthesizer feature macros
+- threading and audio macros
+- product integration macros such as SAPI and OLE paths
+
+Before changing macros:
+
+- classify each macro
+- identify who defines it
+- identify current target impact
+- identify generated artifact impact
+- capture relevant baselines
+
+## Lower-Risk Documentation Work
+
+Documentation-only work is low risk when it:
+
+- describes observed behavior
+- avoids changing build files
+- avoids changing source files
+- avoids changing generated artifacts
+- clearly marks uncertainty
+
+Even documentation should avoid claiming behavior preservation unless checks
+were actually run.
+
+## Recommended Next Safeguards
+
+- Capture Unix and Windows build logs.
+- Capture compiler warning logs by platform.
+- Capture exported symbols for generated libraries.
+- Capture dictionary hashes for each language.
+- Capture dist tree manifests for Unix, VS2022, and VS6.
+- Capture representative audio output from fixed text before refactoring.

--- a/docs/modernization/WARNING_CLEANUP_PLAN.md
+++ b/docs/modernization/WARNING_CLEANUP_PLAN.md
@@ -116,6 +116,29 @@ Status: completed and locally verified on 2026-05-15.
 This result is evidence for the targeted warning disappearing in the local Unix
 capture. It does not prove broad behavior preservation.
 
+## Round 2 Refreshed Baseline
+
+The refreshed local round-2 baseline is
+`baseline-runs/unix-cleanup-warning-round-2-001/`.
+
+The warning summary generated before the temporary-file category existed
+reported 3 warning-like lines, all under `uncategorized`. The corresponding
+`make.log` lines were linker diagnostics for `src/licunix/src/liceninc.c:44`:
+
+```text
+warning: the use of `tmpnam' is dangerous, better use `mkstemp'
+```
+
+These diagnostics should be categorized as `unsafe temporary file API` by the
+baseline warning summarizer. They are intentionally deferred from source cleanup
+because replacing `tmpnam`, `mktemp`, `tempnam`, or related temporary-file
+flows can alter file-creation behavior, permissions, collision handling, and
+cleanup paths.
+
+This means the refreshed round-2 baseline does not currently provide an
+eligible next source cleanup slice under the current constraints. Do not treat
+the `tmpnam` warning as fixed.
+
 ## Avoid Initially
 
 Do not touch these areas in the first warning cleanup PR:

--- a/docs/modernization/WARNING_CLEANUP_PLAN.md
+++ b/docs/modernization/WARNING_CLEANUP_PLAN.md
@@ -2,11 +2,12 @@
 
 ## Purpose
 
-This is a planning document only. No source cleanup is being done yet.
+This document tracks small, low-risk warning cleanup plans and records focused
+cleanup results once they have local verification evidence.
 
-The goal is to choose a small, low-risk first warning cleanup category based on
-the local Unix warning baseline, while preserving DECtalk behavior and avoiding
-high-risk synthesis, dictionary, API, threading, and audio areas.
+The initial goal was to choose a small, low-risk first warning cleanup category
+based on the local Unix warning baseline, while preserving DECtalk behavior and
+avoiding high-risk synthesis, dictionary, API, threading, and audio areas.
 
 The warning evidence comes from `baseline-runs/unix-001/warnings-summary.md`,
 generated from the local Unix build logs. The summary is heuristic and counts
@@ -84,6 +85,36 @@ Why this is lower risk:
 Any cleanup still needs inspection before editing. If the two `liceninc.c`
 files differ meaningfully, avoid mechanical mirroring and document the
 difference before deciding whether both should change.
+
+## First Cleanup Result
+
+Status: completed and locally verified on 2026-05-15.
+
+- Source file changed: `src/licunix/src/liceninc.c`.
+- Warning targeted:
+  `liceninc.c:71:48: warning: '%s' directive writing up to 999 bytes into a region of size 991 [-Wformat-overflow=]`.
+- Before baseline inspected: `baseline-runs/unix-001/`.
+- After baseline inspected: `baseline-runs/unix-after-liceninc-001/`.
+- The cleanup changed only the `licenses:` line generation from unbounded
+  `sprintf(line,"licenses:%s\n",encrypt)` to checked `snprintf` bounded by
+  `sizeof(line)`.
+- `autoreconf`, `configure`, `make`, and warning summarization all exited 0 in
+  the after capture.
+- The three before-baseline `[-Wformat-overflow=]` warnings for `liceninc.c:71`
+  disappeared in the after capture.
+- The after warning summary reported 2 warning-like lines, both related to the
+  existing `tmpnam` linker warning at `liceninc.c:44`.
+- The after `make.log` appears incremental and is much shorter than the
+  original baseline log, so the warning-count drop should not be treated as
+  broad whole-repo warning cleanup.
+- This cleanup did not touch synthesis, audio, threading, dictionaries, public
+  API files, build files, macros, `src/license/LICENINC/liceninc.c`, or the
+  separate `tmpnam` warning.
+- `baseline-runs/` remains local generated output and should not be committed
+  unless explicitly approved.
+
+This result is evidence for the targeted warning disappearing in the local Unix
+capture. It does not prove broad behavior preservation.
 
 ## Avoid Initially
 

--- a/docs/modernization/WARNING_CLEANUP_PLAN.md
+++ b/docs/modernization/WARNING_CLEANUP_PLAN.md
@@ -1,0 +1,166 @@
+# Warning Cleanup Plan
+
+## Purpose
+
+This is a planning document only. No source cleanup is being done yet.
+
+The goal is to choose a small, low-risk first warning cleanup category based on
+the local Unix warning baseline, while preserving DECtalk behavior and avoiding
+high-risk synthesis, dictionary, API, threading, and audio areas.
+
+The warning evidence comes from `baseline-runs/unix-001/warnings-summary.md`,
+generated from the local Unix build logs. The summary is heuristic and counts
+warning-like lines, not necessarily unique compiler diagnostics.
+
+## Observed Warning Categories
+
+The local Unix baseline warning summary reported 1,837 warning-like lines.
+
+| Category | Count |
+| --- | ---: |
+| unknown compiler warning | 1,669 |
+| uninitialized variable | 112 |
+| format string mismatch | 24 |
+| uncategorized | 23 |
+| unused variable/function/parameter | 6 |
+| integer conversion / truncation | 3 |
+
+Zero-count categories in this run included:
+
+- missing prototype / implicit declaration
+- incompatible pointer type
+- pointer/integer conversion
+- signed/unsigned comparison
+- deprecated declaration/API
+- macro redefinition
+- unreachable/dead code
+- syntax/preprocessor
+
+Notable warning markers from the larger `unknown compiler warning` group
+included `-Wdiscarded-qualifiers`, `-Wmisleading-indentation`, `-Wparentheses`,
+`-Wcomment`, `-Wchar-subscripts`, `-Wuse-after-free`, `-Wswitch`,
+`-Wold-style-definition`, `-Wreturn-type`, and related diagnostics. These need
+separate review before cleanup because many examples touch parser, language, or
+compatibility code.
+
+## Safest First Cleanup Category
+
+The safest first cleanup category should be the narrow format-overflow /
+format-string family, but only outside behavior-critical synthesis, dictionary,
+API, threading, and audio paths.
+
+This keeps the first cleanup PR small and reviewable. It also avoids starting in
+areas that can alter speech output, dictionary behavior, public ABI, callback
+timing, audio output, or platform threading behavior.
+
+## First Concrete Cleanup Slice
+
+Recommended first target:
+
+- `[-Wformat-overflow=]` warnings in `liceninc.c`
+
+Representative warning from the local baseline:
+
+```text
+liceninc.c:71:48: warning: '%s' directive writing up to 999 bytes into a region of size 991 [-Wformat-overflow=]
+```
+
+Likely files:
+
+- `src/licunix/src/liceninc.c`
+- possible mirrored or related file, if present:
+  `src/license/LICENINC/liceninc.c`
+
+Why this is lower risk:
+
+- The baseline shows a small number of warning lines for this marker.
+- The warning appears to be a bounded string formatting issue.
+- The likely files are outside core synthesis, audio, threading, public API,
+  and dictionary lookup paths.
+- The fix is likely to be limited to bounded formatting or buffer sizing.
+- A focused PR can verify that the targeted warning count decreases without
+  mixing in unrelated warning categories.
+
+Any cleanup still needs inspection before editing. If the two `liceninc.c`
+files differ meaningfully, avoid mechanical mirroring and document the
+difference before deciding whether both should change.
+
+## Avoid Initially
+
+Do not touch these areas in the first warning cleanup PR:
+
+- `src/dapi/src/lts`
+- `src/dapi/src/ph`
+- `src/dapi/src/vtm`
+- `src/dapi/src/hlsyn`
+- `src/dapi/src/dic`
+- `src/dapi/src/api`
+- `src/dapi/src/nt`
+- public headers
+- `cm_prot.h` inline/prototype warnings
+- uninitialized warnings in phoneme/intonation files
+- `mktemp` replacement in `dtmmio.c`
+
+Reasons to avoid these initially:
+
+- `lts`, `ph`, `vtm`, and `hlsyn` can affect speech, phoneme, intonation, and
+  timing output.
+- `dic` changes can affect dictionary generation, loading, lookup, and packaged
+  dictionaries.
+- `api`, public headers, and exported symbols can affect ABI compatibility.
+- `nt` code includes threading, queue, pipe, callback, and audio behavior.
+- `cm_prot.h` warnings may involve parser helper linkage or inline semantics.
+- uninitialized warnings in phoneme/intonation code may require behavior-level
+  analysis, not mechanical initialization.
+- replacing `mktemp` can change file creation behavior and needs a focused
+  portability/security review.
+
+## Verification Before The First Cleanup PR
+
+Before any source edit:
+
+- Save the current warning summary from
+  `baseline-runs/unix-001/warnings-summary.md`.
+- Identify the exact target warning lines in
+  `baseline-runs/unix-001/make.log`.
+- Confirm the target file is outside the highest-risk paths listed in
+  `docs/modernization/RISK_AREAS.md`.
+- Confirm the working tree is clean except for intentional documentation or
+  local generated baseline output.
+- Inspect both likely `liceninc.c` files before deciding whether one or both
+  need changes.
+- Optionally capture a current dist manifest before source edits.
+- Optionally capture current audio outputs before source edits.
+
+Do not claim behavior preservation from these pre-checks alone.
+
+## Verification After The First Cleanup PR
+
+After the focused cleanup:
+
+- Rerun the Unix build capture.
+- Regenerate the warning summary.
+- Confirm the targeted `-Wformat-overflow` warning lines decreased or
+  disappeared.
+- Confirm unrelated warning categories did not unexpectedly increase.
+- Run `git diff --check`.
+- Review the source diff to confirm it is limited to the planned warning slice.
+- Optionally rerun audio capture and compare against the previous local
+  baseline.
+- Optionally recapture a dist manifest and compare it to the previous local
+  manifest if one exists.
+
+Do not claim behavior preservation unless the relevant baseline checks were
+run and reviewed.
+
+## Rollback Criteria
+
+Rollback or revise the cleanup if:
+
+- the build fails
+- warning counts increase in unrelated categories
+- generated artifacts or dist outputs unexpectedly change
+- audio/file baseline output changes without explanation
+- the fix touches broader source or build behavior than planned
+- the fix requires changes in high-risk synthesis, dictionary, API, threading,
+  audio, or public header areas

--- a/src/licunix/src/liceninc.c
+++ b/src/licunix/src/liceninc.c
@@ -68,7 +68,12 @@ int main(void)
 			memset(line,0,999);
 			sprintf(decrypt,"%d",licenses);
 			encryptString(decrypt,LICENSE_KEY,encrypt);
-			sprintf(line,"licenses:%s\n",encrypt);
+			ret_value=snprintf(line,sizeof(line),"licenses:%s\n",encrypt);
+			if (ret_value < 0 || ret_value >= (int)sizeof(line))
+			{
+				fprintf(stderr,"cannot format the license key\n");
+				continue;
+			}
 		
 		}
 		fputs(line,config_file);

--- a/tests/golden/input/basic.txt
+++ b/tests/golden/input/basic.txt
@@ -1,0 +1,13 @@
+This is a basic DECtalk modernization baseline input.
+
+The quick brown fox jumps over the lazy dog.
+Pack my box with five dozen liquor jugs.
+
+Hello, world. This sentence has commas, periods, and a short pause.
+Can DECtalk ask a question? Yes, it can answer one too.
+
+Dr. Smith met Mr. Jones at 3 p.m.
+The U.S. sample includes abbreviations and initials.
+
+Please read this text at the default settings.
+This file should remain stable after baseline artifacts are captured.

--- a/tests/golden/input/commands.txt
+++ b/tests/golden/input/commands.txt
@@ -1,0 +1,19 @@
+This file contains conservative DECtalk command samples.
+
+[:rate 180] This sentence uses a rate command.
+[:rate 200] This sentence is a little faster.
+[:rate 150] This sentence is a little slower.
+[:rate 180] The rate is restored for the remaining text.
+
+[:name paul] This sentence uses the Paul voice.
+[:name betty] This sentence uses the Betty voice.
+[:name harry] This sentence uses the Harry voice.
+[:name paul] The voice is restored to Paul.
+
+[:punct some] Some punctuation should be spoken when punctuation mode allows it.
+[:punct none] Punctuation mode is restored to none.
+
+[:phoneme on] h eh l ow [:phoneme off]
+Phoneme mode has been turned off again.
+
+End of command baseline input.

--- a/tests/golden/input/languages.txt
+++ b/tests/golden/input/languages.txt
@@ -1,0 +1,21 @@
+This file contains short language and region samples for later baseline runs.
+
+US English:
+The color of the small theater sign was bright red.
+
+UK English:
+The colour of the small theatre sign was bright red.
+
+Spanish:
+Buenos dias. Esta es una prueba breve de DECtalk.
+
+Latin American Spanish:
+Hola. Esta prueba usa palabras comunes de America Latina.
+
+German:
+Guten Tag. Dies ist ein kurzer deutscher Testsatz.
+
+French:
+Bonjour. Ceci est une courte phrase de test en francais.
+
+Run each section with the matching language build when that build is available.

--- a/tests/golden/input/numbers_dates.txt
+++ b/tests/golden/input/numbers_dates.txt
@@ -1,0 +1,30 @@
+This file contains numbers, dates, times, and mixed tokens.
+
+Numbers:
+Zero, one, two, three, ten, eleven, twenty, one hundred, and one thousand.
+The values are 3, 14, 159, 2653, and 58979.
+The signed values are -1, -42, and +17.
+
+Ordinals:
+First, second, third, fourth, tenth, twenty first, and one hundredth.
+
+Currency-like values:
+$1.00, $12.50, $100.05, and $1,234.56.
+
+Dates:
+January 1, 2000.
+December 31, 1999.
+05/15/2026.
+2026-05-15.
+
+Times:
+12:00 a.m.
+8:30 a.m.
+1:45 p.m.
+23:59.
+
+Mixed tokens:
+Version 4.3.0.
+Room 101B.
+Call 555-0100.
+Serial number A17-B42-C999.

--- a/tools/baseline/README.md
+++ b/tools/baseline/README.md
@@ -87,6 +87,42 @@ It uses available inspection tools where practical:
 If one artifact cannot be inspected, the script records that failure in the
 summary and continues with the remaining artifacts.
 
+### `capture_unix_build.sh`
+
+Usage:
+
+```sh
+tools/baseline/capture_unix_build.sh OUT_DIR
+```
+
+Writes:
+
+- `OUT_DIR/autoreconf.log`
+- `OUT_DIR/configure.log`
+- `OUT_DIR/make.log`
+- `OUT_DIR/build-status.txt`
+- `OUT_DIR/git/` when `capture_git_state.sh` is executable
+- `OUT_DIR/warnings-summary.md` when Python 3 and `summarize_warnings.py` are
+  available
+
+This captures the existing Unix build flow from `src/`:
+
+```sh
+autoreconf -i
+./configure
+make
+```
+
+The script records each step's exit code. If `autoreconf -i` fails, it skips
+`./configure` and `make`. If `./configure` fails, it skips `make`. Warning
+summary generation is best-effort and does not determine the build capture exit
+code.
+
+This helper does not run audio tools or claim behavior preservation. It is meant
+to capture logs from the existing Unix build path for later review. Because the
+existing Unix flow generates files under `src/`, run it from a checkout where
+generated Autotools and build outputs are acceptable, or from a disposable copy.
+
 ## Limitations
 
 - These scripts are POSIX shell scripts and use `set -eu`.
@@ -101,6 +137,9 @@ summary and continues with the remaining artifacts.
 - The scripts do not require DECtalk to have built successfully, except that
   `capture_dist_manifest.sh` and `capture_symbols.sh` need existing directories
   containing the artifacts you want to inspect.
+- `capture_unix_build.sh` runs the existing Autotools/Make flow and therefore
+  requires the usual Unix build tools such as `autoreconf`, `./configure`
+  support files, `make`, a C compiler, and platform libraries.
 
 ## Example
 
@@ -109,6 +148,7 @@ mkdir -p baseline-out
 tools/baseline/capture_git_state.sh baseline-out/git
 tools/baseline/capture_dist_manifest.sh dist baseline-out/dist
 tools/baseline/capture_symbols.sh dist baseline-out/symbols
+tools/baseline/capture_unix_build.sh baseline-out/unix-build
 ```
 
 Do not claim behavior preservation from these captures alone. They provide

--- a/tools/baseline/README.md
+++ b/tools/baseline/README.md
@@ -123,6 +123,27 @@ to capture logs from the existing Unix build path for later review. Because the
 existing Unix flow generates files under `src/`, run it from a checkout where
 generated Autotools and build outputs are acceptable, or from a disposable copy.
 
+### `summarize_warnings.py`
+
+Usage:
+
+```sh
+python3 tools/baseline/summarize_warnings.py --output OUT.md LOG1 [LOG2 ...]
+```
+
+Writes a Markdown warning inventory with total warning-like line counts,
+category counts, detected warning markers where available, and representative
+examples per category. The script uses only the Python 3 standard library and
+does not modify the input logs or source tree.
+
+Warning categories are heuristic and include compiler-agnostic groups for
+format strings, uninitialized variables, unused symbols, pointer/integer
+conversions, and unsafe temporary-file APIs. The `unsafe temporary file API`
+category catches diagnostics mentioning `tmpnam`, `mktemp`, `tempnam`, or
+guidance to use `mkstemp`. This category is for inventory only; it does not fix
+temporary-file behavior or imply that such behavior can be changed without a
+focused review.
+
 ### `capture_audio_outputs.sh`
 
 Usage:

--- a/tools/baseline/README.md
+++ b/tools/baseline/README.md
@@ -1,9 +1,9 @@
 # Baseline Capture Helpers
 
-These scripts capture read-only baseline metadata for DECtalk modernization.
-They are helpers only: they do not build DECtalk, run DECtalk binaries, generate
-audio, generate dictionaries, edit source files, edit build files, or prove that
-behavior has been preserved.
+These scripts capture baseline evidence for DECtalk modernization. They are
+helpers only: they do not build DECtalk unless explicitly documented for a
+specific helper, generate dictionaries, edit source files, edit build files, or
+prove that behavior has been preserved.
 
 Each script writes only under a caller-specified output directory. The scripts
 create that output directory if needed.
@@ -123,6 +123,50 @@ to capture logs from the existing Unix build path for later review. Because the
 existing Unix flow generates files under `src/`, run it from a checkout where
 generated Autotools and build outputs are acceptable, or from a disposable copy.
 
+### `capture_audio_outputs.sh`
+
+Usage:
+
+```sh
+tools/baseline/capture_audio_outputs.sh SAY_EXE INPUT_DIR OUT_DIR
+```
+
+Example:
+
+```sh
+tools/baseline/capture_audio_outputs.sh \
+  src/samplosf/build/speak/6.6.114.1-microsoft-standard-WSL2/say \
+  tests/golden/input \
+  baseline-runs/audio-001
+```
+
+Writes:
+
+- `OUT_DIR/audio/`
+- `OUT_DIR/logs/`
+- `OUT_DIR/commands.txt`
+- `OUT_DIR/capture-status.txt`
+- `OUT_DIR/audio-manifest.txt`
+- `OUT_DIR/audio-sha256.txt` when `sha256sum` or `shasum` is available
+
+The script runs a caller-supplied built `say` executable once per `*.txt` input
+file. It uses file output to avoid live audio hardware where practical:
+
+```sh
+SAY_EXE -fi INPUT_FILE -fo OUT_DIR/audio/BASENAME.wav
+```
+
+It captures stdout and stderr for each input, records the exact command used,
+records per-input success or failure, and continues through all inputs even if
+one input fails. It exits nonzero at the end if any input failed.
+
+This helper does not build DECtalk. It expects `SAY_EXE` to already exist and be
+executable. Command-line compatibility is still part of the baseline evidence:
+some checked-in `say` sources document `-fi`/`-fo`, while another sample
+documents `-w` plus stdin. If a particular built `say` does not support
+`-fi`/`-fo`, the failure should be kept with the captured status and logs rather
+than silently treated as success.
+
 ## Limitations
 
 - These scripts are POSIX shell scripts and use `set -eu`.
@@ -140,6 +184,9 @@ generated Autotools and build outputs are acceptable, or from a disposable copy.
 - `capture_unix_build.sh` runs the existing Autotools/Make flow and therefore
   requires the usual Unix build tools such as `autoreconf`, `./configure`
   support files, `make`, a C compiler, and platform libraries.
+- `capture_audio_outputs.sh` requires a previously built `say` executable and
+  records file-output artifacts only. It does not compare audio, compute audio
+  metrics, or prove behavior preservation.
 
 ## Example
 
@@ -149,6 +196,7 @@ tools/baseline/capture_git_state.sh baseline-out/git
 tools/baseline/capture_dist_manifest.sh dist baseline-out/dist
 tools/baseline/capture_symbols.sh dist baseline-out/symbols
 tools/baseline/capture_unix_build.sh baseline-out/unix-build
+tools/baseline/capture_audio_outputs.sh path/to/say tests/golden/input baseline-out/audio
 ```
 
 Do not claim behavior preservation from these captures alone. They provide

--- a/tools/baseline/README.md
+++ b/tools/baseline/README.md
@@ -167,6 +167,48 @@ documents `-w` plus stdin. If a particular built `say` does not support
 `-fi`/`-fo`, the failure should be kept with the captured status and logs rather
 than silently treated as success.
 
+### `compare_audio_outputs.py`
+
+Usage:
+
+```sh
+python3 tools/baseline/compare_audio_outputs.py \
+  --baseline OLD_CAPTURE_DIR \
+  --candidate NEW_CAPTURE_DIR \
+  --output REPORT.md
+```
+
+Example:
+
+```sh
+python3 tools/baseline/compare_audio_outputs.py \
+  --baseline baseline-runs/audio-001 \
+  --candidate baseline-runs/audio-002 \
+  --output baseline-runs/audio-002/compare-audio-001.md
+```
+
+The script compares two directories produced by `capture_audio_outputs.sh`.
+Expected inputs are capture directories with `audio/` subdirectories containing
+the generated audio/file-output artifacts.
+
+It writes a Markdown report with:
+
+- compared directories
+- summary counts
+- exact match status
+- missing files
+- extra files
+- differing file sizes and SHA-256 hashes
+- WAV metadata comparison when files are valid WAV files
+- limitations
+
+Exit status is 0 only when all compared artifacts exist and match exactly by
+SHA-256. It exits nonzero if files are missing, extra, unreadable, or different.
+
+This helper uses only the Python 3 standard library. It does not require NumPy,
+SciPy, ffmpeg, audio playback, or live audio hardware. It does not compute RMS,
+peak, perceptual difference, or sample-level deltas.
+
 ## Limitations
 
 - These scripts are POSIX shell scripts and use `set -eu`.
@@ -187,6 +229,9 @@ than silently treated as success.
 - `capture_audio_outputs.sh` requires a previously built `say` executable and
   records file-output artifacts only. It does not compare audio, compute audio
   metrics, or prove behavior preservation.
+- `compare_audio_outputs.py` performs strict file-level comparison. Exact
+  equality is useful for same-platform repeatability checks, but cross-platform
+  captures may need later audio-aware tolerances.
 
 ## Example
 

--- a/tools/baseline/README.md
+++ b/tools/baseline/README.md
@@ -1,0 +1,115 @@
+# Baseline Capture Helpers
+
+These scripts capture read-only baseline metadata for DECtalk modernization.
+They are helpers only: they do not build DECtalk, run DECtalk binaries, generate
+audio, generate dictionaries, edit source files, edit build files, or prove that
+behavior has been preserved.
+
+Each script writes only under a caller-specified output directory. The scripts
+create that output directory if needed.
+
+## Scripts
+
+### `capture_git_state.sh`
+
+Usage:
+
+```sh
+tools/baseline/capture_git_state.sh OUT_DIR
+```
+
+Writes:
+
+- `OUT_DIR/git-status.txt`
+- `OUT_DIR/git-branch.txt`
+- `OUT_DIR/git-head.txt`
+- `OUT_DIR/git-remotes.txt`
+- `OUT_DIR/git-diff-stat.txt`
+
+This records repository state using read-only `git` commands. It does not add,
+checkout, reset, clean, commit, or otherwise modify the working tree.
+
+If Git refuses to inspect the checkout because of safe-directory ownership
+checks, run with:
+
+```sh
+GIT_SAFE_DIRECTORY=/home/yam/dectalk tools/baseline/capture_git_state.sh OUT_DIR
+```
+
+### `capture_dist_manifest.sh`
+
+Usage:
+
+```sh
+tools/baseline/capture_dist_manifest.sh DIST_DIR OUT_DIR
+```
+
+Writes:
+
+- `OUT_DIR/dist-manifest.txt`
+- `OUT_DIR/dist-sha256.txt` when `sha256sum` or `shasum` is available
+
+This records paths, file types, sizes, permissions, and mtimes for an existing
+dist or install tree. It also captures SHA-256 hashes for regular files when a
+supported hash command is available.
+
+The script expects `DIST_DIR` to already exist. It does not run a build or create
+a dist tree.
+
+### `capture_symbols.sh`
+
+Usage:
+
+```sh
+tools/baseline/capture_symbols.sh ARTIFACT_DIR OUT_DIR
+```
+
+Writes:
+
+- `OUT_DIR/symbols-summary.txt`
+- one `*.symbols.txt` file per inspected artifact
+
+The script searches `ARTIFACT_DIR` for shared-library-style artifacts:
+
+- `*.so`
+- `*.so.*`
+- `*.dylib`
+- `*.dll`
+- `*.a`
+
+It uses available inspection tools where practical:
+
+- `nm`
+- `objdump`
+- `otool`
+- `dumpbin`
+
+If one artifact cannot be inspected, the script records that failure in the
+summary and continues with the remaining artifacts.
+
+## Limitations
+
+- These scripts are POSIX shell scripts and use `set -eu`.
+- Linux and macOS differ in `stat` and hashing tools; the scripts include
+  fallbacks for common GNU and BSD/macOS forms.
+- Windows DLL symbol capture is best-effort from POSIX shell. Full Windows
+  export capture may require running on Windows with `dumpbin` or compatible
+  LLVM tooling available.
+- Symbol output formats differ by tool and platform. Treat the files as raw
+  baseline artifacts until a later comparison format is defined.
+- The scripts do not require live audio hardware.
+- The scripts do not require DECtalk to have built successfully, except that
+  `capture_dist_manifest.sh` and `capture_symbols.sh` need existing directories
+  containing the artifacts you want to inspect.
+
+## Example
+
+```sh
+mkdir -p baseline-out
+tools/baseline/capture_git_state.sh baseline-out/git
+tools/baseline/capture_dist_manifest.sh dist baseline-out/dist
+tools/baseline/capture_symbols.sh dist baseline-out/symbols
+```
+
+Do not claim behavior preservation from these captures alone. They provide
+evidence for later reviews and comparisons.

--- a/tools/baseline/capture_audio_outputs.sh
+++ b/tools/baseline/capture_audio_outputs.sh
@@ -1,0 +1,174 @@
+#!/bin/sh
+set -eu
+
+usage() {
+    echo "Usage: tools/baseline/capture_audio_outputs.sh SAY_EXE INPUT_DIR OUT_DIR" >&2
+}
+
+if [ "$#" -ne 3 ]; then
+    usage
+    exit 2
+fi
+
+SAY_EXE=$1
+INPUT_DIR=$2
+OUT_DIR=$3
+
+if [ ! -f "AGENTS.md" ] || [ ! -d "tools/baseline" ]; then
+    echo "error: must be run from the repository root" >&2
+    exit 1
+fi
+
+if [ ! -x "$SAY_EXE" ]; then
+    echo "error: SAY_EXE is not executable: $SAY_EXE" >&2
+    exit 1
+fi
+
+if [ ! -d "$INPUT_DIR" ]; then
+    echo "error: INPUT_DIR does not exist or is not a directory: $INPUT_DIR" >&2
+    exit 1
+fi
+
+AUDIO_DIR=$OUT_DIR/audio
+LOG_DIR=$OUT_DIR/logs
+STATUS_FILE=$OUT_DIR/capture-status.txt
+COMMANDS_FILE=$OUT_DIR/commands.txt
+MANIFEST_FILE=$OUT_DIR/audio-manifest.txt
+SHA_FILE=$OUT_DIR/audio-sha256.txt
+
+mkdir -p "$AUDIO_DIR" "$LOG_DIR"
+
+hash_tool=
+if command -v sha256sum >/dev/null 2>&1; then
+    hash_tool=sha256sum
+elif command -v shasum >/dev/null 2>&1; then
+    hash_tool="shasum -a 256"
+fi
+
+hash_file() {
+    file=$1
+    if [ "$hash_tool" = "" ] || [ ! -f "$file" ]; then
+        printf 'unavailable'
+        return 0
+    fi
+    # shellcheck disable=SC2086
+    $hash_tool "$file" | awk '{print $1}'
+}
+
+file_size() {
+    file=$1
+    if [ ! -f "$file" ]; then
+        printf 'missing'
+        return 0
+    fi
+    if stat -c '%s' "$file" 2>/dev/null; then
+        return 0
+    fi
+    if stat -f '%z' "$file" 2>/dev/null; then
+        return 0
+    fi
+    printf 'unknown\n'
+}
+
+sanitize_name() {
+    printf '%s' "$1" | sed 's/[^A-Za-z0-9._-]/_/g'
+}
+
+{
+    echo "# DECtalk audio/file-output capture status"
+    echo "# Captured at: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "# Repository root: $(pwd)"
+    echo "# SAY_EXE: $SAY_EXE"
+    echo "# INPUT_DIR: $INPUT_DIR"
+    echo "# OUT_DIR: $OUT_DIR"
+    echo "# Command template: SAY_EXE -fi INPUT_FILE -fo OUT_WAV"
+    echo "# This capture does not prove behavior preservation."
+    echo
+    echo "input	exit_code	output	stdout	stderr"
+} > "$STATUS_FILE"
+
+{
+    echo "# DECtalk audio/file-output capture commands"
+    echo "# Captured at: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "# Note: this helper uses -fi/-fo. Some SAY variants document -w with stdin instead."
+} > "$COMMANDS_FILE"
+
+{
+    echo "# DECtalk audio/file-output manifest"
+    echo "# Captured at: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "# Columns: input input_size input_sha256 output output_size output_sha256 stdout stderr exit_code"
+} > "$MANIFEST_FILE"
+
+if [ "$hash_tool" != "" ]; then
+    {
+        echo "# SHA-256 hashes from: $hash_tool"
+        echo "# Captured at: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    } > "$SHA_FILE"
+else
+    rm -f "$SHA_FILE"
+fi
+
+found=0
+failed=0
+
+for input in "$INPUT_DIR"/*.txt; do
+    if [ ! -f "$input" ]; then
+        continue
+    fi
+
+    found=1
+    name=$(basename "$input" .txt)
+    safe_name=$(sanitize_name "$name")
+    output=$AUDIO_DIR/$safe_name.wav
+    stdout_log=$LOG_DIR/$safe_name.stdout.txt
+    stderr_log=$LOG_DIR/$safe_name.stderr.txt
+
+    # The current Unix sample SAY documents -fi/-fo, while another SAY sample
+    # documents -w plus stdin. Use the requested -fi/-fo form and record the
+    # exact command so incompatible SAY variants are visible in the status.
+    printf '%s -fi %s -fo %s\n' "$SAY_EXE" "$input" "$output" >> "$COMMANDS_FILE"
+
+    if "$SAY_EXE" -fi "$input" -fo "$output" > "$stdout_log" 2> "$stderr_log"; then
+        rc=0
+    else
+        rc=$?
+        failed=1
+    fi
+
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+        "$input" "$rc" "$output" "$stdout_log" "$stderr_log" >> "$STATUS_FILE"
+
+    input_size=$(file_size "$input")
+    output_size=$(file_size "$output")
+    input_hash=$(hash_file "$input")
+    output_hash=$(hash_file "$output")
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$input" "$input_size" "$input_hash" \
+        "$output" "$output_size" "$output_hash" \
+        "$stdout_log" "$stderr_log" "$rc" >> "$MANIFEST_FILE"
+
+    if [ "$hash_tool" != "" ]; then
+        {
+            # shellcheck disable=SC2086
+            $hash_tool "$input"
+            if [ -f "$output" ]; then
+                # shellcheck disable=SC2086
+                $hash_tool "$output"
+            fi
+        } >> "$SHA_FILE"
+    fi
+done
+
+if [ "$found" -eq 0 ]; then
+    echo "error: no *.txt input files found in INPUT_DIR: $INPUT_DIR" >&2
+    echo "no-inputs	1	-	-	-" >> "$STATUS_FILE"
+    exit 1
+fi
+
+if [ "$failed" -ne 0 ]; then
+    echo "capture completed with one or more failed inputs; see $STATUS_FILE" >&2
+    exit 1
+fi
+
+echo "capture completed successfully; see $STATUS_FILE"

--- a/tools/baseline/capture_dist_manifest.sh
+++ b/tools/baseline/capture_dist_manifest.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+set -eu
+
+usage() {
+    echo "Usage: tools/baseline/capture_dist_manifest.sh DIST_DIR OUT_DIR" >&2
+}
+
+if [ "$#" -ne 2 ]; then
+    usage
+    exit 2
+fi
+
+DIST_DIR=$1
+OUT_DIR=$2
+
+if [ ! -d "$DIST_DIR" ]; then
+    echo "error: DIST_DIR does not exist or is not a directory: $DIST_DIR" >&2
+    exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+stat_fields() {
+    path=$1
+    if stat -c '%s	%a	%Y' "$path" 2>/dev/null; then
+        return 0
+    fi
+    if stat -f '%z	%Lp	%m' "$path" 2>/dev/null; then
+        return 0
+    fi
+    printf 'unknown\tunknown\tunknown\n'
+}
+
+path_type() {
+    path=$1
+    if [ -L "$path" ]; then
+        printf 'symlink'
+    elif [ -f "$path" ]; then
+        printf 'file'
+    elif [ -d "$path" ]; then
+        printf 'dir'
+    else
+        printf 'other'
+    fi
+}
+
+{
+    echo "# DECtalk dist/install manifest"
+    echo "# Captured at: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "# Source directory: $DIST_DIR"
+    echo "# Columns: type size mode mtime path"
+    (
+        cd "$DIST_DIR"
+        find . -print | sort | while IFS= read -r path; do
+            rel=${path#./}
+            type=$(path_type "$path")
+            fields=$(stat_fields "$path")
+            printf '%s\t%s\t%s\n' "$type" "$fields" "$rel"
+        done
+    )
+} > "$OUT_DIR/dist-manifest.txt"
+
+if command -v sha256sum >/dev/null 2>&1; then
+    {
+        echo "# SHA-256 hashes from: sha256sum"
+        echo "# Source directory: $DIST_DIR"
+        (
+            cd "$DIST_DIR"
+            find . -type f -print | sort | while IFS= read -r path; do
+                sha256sum "$path"
+            done
+        )
+    } > "$OUT_DIR/dist-sha256.txt"
+elif command -v shasum >/dev/null 2>&1; then
+    {
+        echo "# SHA-256 hashes from: shasum -a 256"
+        echo "# Source directory: $DIST_DIR"
+        (
+            cd "$DIST_DIR"
+            find . -type f -print | sort | while IFS= read -r path; do
+                shasum -a 256 "$path"
+            done
+        )
+    } > "$OUT_DIR/dist-sha256.txt"
+fi

--- a/tools/baseline/capture_git_state.sh
+++ b/tools/baseline/capture_git_state.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -eu
+
+usage() {
+    echo "Usage: tools/baseline/capture_git_state.sh OUT_DIR" >&2
+}
+
+if [ "$#" -ne 1 ]; then
+    usage
+    exit 2
+fi
+
+OUT_DIR=$1
+mkdir -p "$OUT_DIR"
+
+git_cmd() {
+    if [ "${GIT_SAFE_DIRECTORY:-}" != "" ]; then
+        git -c safe.directory="$GIT_SAFE_DIRECTORY" "$@"
+    else
+        git "$@"
+    fi
+}
+
+capture() {
+    out_file=$1
+    shift
+    {
+        echo "# Command: git $*"
+        echo "# Captured at: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        if ! git_cmd "$@"; then
+            echo "# Command failed"
+        fi
+    } > "$out_file" 2>&1
+}
+
+capture "$OUT_DIR/git-status.txt" status --short --branch
+capture "$OUT_DIR/git-branch.txt" branch -vv
+capture "$OUT_DIR/git-head.txt" show -s --format=fuller HEAD
+capture "$OUT_DIR/git-remotes.txt" remote -v
+
+{
+    echo "# Command: git diff --stat"
+    echo "# Captured at: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    if ! git_cmd diff --stat; then
+        echo "# Command failed: git diff --stat"
+    fi
+    echo
+    echo "# Command: git diff --cached --stat"
+    if ! git_cmd diff --cached --stat; then
+        echo "# Command failed: git diff --cached --stat"
+    fi
+} > "$OUT_DIR/git-diff-stat.txt" 2>&1

--- a/tools/baseline/capture_symbols.sh
+++ b/tools/baseline/capture_symbols.sh
@@ -1,0 +1,132 @@
+#!/bin/sh
+set -eu
+
+usage() {
+    echo "Usage: tools/baseline/capture_symbols.sh ARTIFACT_DIR OUT_DIR" >&2
+}
+
+if [ "$#" -ne 2 ]; then
+    usage
+    exit 2
+fi
+
+ARTIFACT_DIR=$1
+OUT_DIR=$2
+
+if [ ! -d "$ARTIFACT_DIR" ]; then
+    echo "error: ARTIFACT_DIR does not exist or is not a directory: $ARTIFACT_DIR" >&2
+    exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+sanitize_name() {
+    printf '%s' "$1" | sed 's#^\./##; s#[^A-Za-z0-9._-]#_#g'
+}
+
+inspect_artifact() {
+    artifact=$1
+    out_file=$2
+    status=1
+
+    {
+        echo "# Artifact: $artifact"
+        echo "# Captured at: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+        if command -v file >/dev/null 2>&1; then
+            echo
+            echo "## file"
+            file "$artifact" || true
+        fi
+
+        if command -v nm >/dev/null 2>&1; then
+            echo
+            echo "## nm -g"
+            if nm -g "$artifact"; then
+                status=0
+            else
+                echo "# nm failed for this artifact"
+            fi
+        fi
+
+        if [ "$status" -ne 0 ] && command -v objdump >/dev/null 2>&1; then
+            echo
+            echo "## objdump -T"
+            if objdump -T "$artifact"; then
+                status=0
+            else
+                echo "# objdump -T failed for this artifact"
+                echo
+                echo "## objdump -t"
+                if objdump -t "$artifact"; then
+                    status=0
+                else
+                    echo "# objdump -t failed for this artifact"
+                fi
+            fi
+        fi
+
+        if [ "$status" -ne 0 ] && command -v otool >/dev/null 2>&1; then
+            echo
+            echo "## otool -Iv"
+            if otool -Iv "$artifact"; then
+                status=0
+            else
+                echo "# otool failed for this artifact"
+            fi
+        fi
+
+        if [ "$status" -ne 0 ] && command -v dumpbin >/dev/null 2>&1; then
+            echo
+            echo "## dumpbin /EXPORTS"
+            if dumpbin /EXPORTS "$artifact"; then
+                status=0
+            else
+                echo "# dumpbin failed for this artifact"
+            fi
+        fi
+
+        if [ "$status" -ne 0 ]; then
+            echo
+            echo "# No available symbol tool succeeded for this artifact"
+        fi
+    } > "$out_file" 2>&1
+
+    return "$status"
+}
+
+SUMMARY="$OUT_DIR/symbols-summary.txt"
+
+{
+    echo "# DECtalk symbol capture summary"
+    echo "# Captured at: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "# Artifact directory: $ARTIFACT_DIR"
+    echo "# Columns: status artifact symbol_file"
+} > "$SUMMARY"
+
+count=0
+LIST_FILE="$OUT_DIR/.symbols-artifacts.$$"
+trap 'rm -f "$LIST_FILE"' EXIT HUP INT TERM
+
+(
+    cd "$ARTIFACT_DIR"
+    find . -type f \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' -o -name '*.dll' -o -name '*.a' \) -print | sort
+) > "$LIST_FILE"
+
+if [ ! -s "$LIST_FILE" ]; then
+    echo "# No shared-library-style artifacts found" >> "$SUMMARY"
+    exit 0
+fi
+
+while IFS= read -r rel_path; do
+    count=$((count + 1))
+    safe=$(sanitize_name "$rel_path")
+    symbol_file="$OUT_DIR/${count}-${safe}.symbols.txt"
+    artifact="$ARTIFACT_DIR/$rel_path"
+
+    if inspect_artifact "$artifact" "$symbol_file"; then
+        printf 'ok\t%s\t%s\n' "$rel_path" "$symbol_file" >> "$SUMMARY"
+    else
+        printf 'failed\t%s\t%s\n' "$rel_path" "$symbol_file" >> "$SUMMARY"
+    fi
+done < "$LIST_FILE"

--- a/tools/baseline/capture_unix_build.sh
+++ b/tools/baseline/capture_unix_build.sh
@@ -1,0 +1,170 @@
+#!/bin/sh
+set -eu
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: tools/baseline/capture_unix_build.sh OUT_DIR
+
+Capture the existing Unix build flow logs from src/:
+  autoreconf -i
+  ./configure
+  make
+
+Writes logs and status files under OUT_DIR.
+EOF
+}
+
+if [ "$#" -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+    usage
+    exit 0
+fi
+
+if [ "$#" -ne 1 ]; then
+    usage
+    exit 2
+fi
+
+if [ ! -f "AGENTS.md" ] || [ ! -f "src/configure.ac" ] || [ ! -d "tools/baseline" ]; then
+    echo "error: run this script from the repository root" >&2
+    exit 1
+fi
+
+REPO_ROOT=$(pwd)
+OUT_DIR=$1
+case "$OUT_DIR" in
+    /*) OUT_DIR_ABS=$OUT_DIR ;;
+    *) OUT_DIR_ABS=$REPO_ROOT/$OUT_DIR ;;
+esac
+
+mkdir -p "$OUT_DIR_ABS"
+
+STATUS_FILE=$OUT_DIR_ABS/build-status.txt
+AUTORECONF_LOG=$OUT_DIR_ABS/autoreconf.log
+CONFIGURE_LOG=$OUT_DIR_ABS/configure.log
+MAKE_LOG=$OUT_DIR_ABS/make.log
+SUMMARY_LOG=$OUT_DIR_ABS/warnings-summary.md
+LAST_RC=0
+
+{
+    echo "# DECtalk Unix build log capture"
+    echo "# Started at: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "# Repository root: $REPO_ROOT"
+    echo "# Output directory: $OUT_DIR_ABS"
+    echo "# This capture does not prove behavior preservation."
+    echo
+} > "$STATUS_FILE"
+
+append_status() {
+    step=$1
+    code=$2
+    log_file=$3
+    command_text=$4
+    {
+        echo "step: $step"
+        echo "command: $command_text"
+        echo "exit_code: $code"
+        echo "log: $log_file"
+        echo "timestamp: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        echo
+    } >> "$STATUS_FILE"
+}
+
+write_skipped_log() {
+    log_file=$1
+    reason=$2
+    {
+        echo "# Step skipped"
+        echo "# Reason: $reason"
+        echo "# Timestamp: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    } > "$log_file"
+}
+
+run_step() {
+    step=$1
+    log_file=$2
+    command_text=$3
+    shift 3
+
+    echo "running $step: $command_text" >&2
+    set +e
+    (
+        cd "$REPO_ROOT/src"
+        "$@"
+    ) > "$log_file" 2>&1
+    rc=$?
+    set -e
+    LAST_RC=$rc
+
+    append_status "$step" "$rc" "$log_file" "$command_text"
+    if [ "$rc" -ne 0 ]; then
+        echo "error: $step failed with exit code $rc; see $log_file" >&2
+    fi
+    return "$rc"
+}
+
+capture_git_state() {
+    git_capture=$REPO_ROOT/tools/baseline/capture_git_state.sh
+    if [ -x "$git_capture" ]; then
+        echo "capturing git state" >&2
+        set +e
+        GIT_SAFE_DIRECTORY=${GIT_SAFE_DIRECTORY:-$REPO_ROOT} "$git_capture" "$OUT_DIR_ABS/git"
+        rc=$?
+        set -e
+        append_status "git-state" "$rc" "$OUT_DIR_ABS/git" "$git_capture $OUT_DIR_ABS/git"
+        if [ "$rc" -ne 0 ]; then
+            echo "warning: git state capture failed with exit code $rc" >&2
+        fi
+    else
+        append_status "git-state" "skipped" "$OUT_DIR_ABS/git" "capture_git_state.sh not executable"
+    fi
+}
+
+summarize_warnings() {
+    summarizer=$REPO_ROOT/tools/baseline/summarize_warnings.py
+    if command -v python3 >/dev/null 2>&1 && [ -f "$summarizer" ]; then
+        echo "summarizing warnings" >&2
+        set +e
+        python3 "$summarizer" \
+            --output "$SUMMARY_LOG" \
+            "$AUTORECONF_LOG" "$CONFIGURE_LOG" "$MAKE_LOG"
+        rc=$?
+        set -e
+        append_status "warning-summary" "$rc" "$SUMMARY_LOG" "python3 $summarizer --output $SUMMARY_LOG ..."
+        if [ "$rc" -ne 0 ]; then
+            echo "warning: warning summarization failed with exit code $rc" >&2
+        fi
+    else
+        append_status "warning-summary" "skipped" "$SUMMARY_LOG" "python3 or summarize_warnings.py unavailable"
+    fi
+}
+
+final_rc=0
+
+capture_git_state
+
+if run_step "autoreconf" "$AUTORECONF_LOG" "autoreconf -i" autoreconf -i; then
+    if run_step "configure" "$CONFIGURE_LOG" "./configure" ./configure; then
+        if ! run_step "make" "$MAKE_LOG" "make" make; then
+            final_rc=$LAST_RC
+        fi
+    else
+        final_rc=$LAST_RC
+        write_skipped_log "$MAKE_LOG" "configure failed"
+        append_status "make" "skipped" "$MAKE_LOG" "make"
+    fi
+else
+    final_rc=$LAST_RC
+    write_skipped_log "$CONFIGURE_LOG" "autoreconf failed"
+    write_skipped_log "$MAKE_LOG" "autoreconf failed"
+    append_status "configure" "skipped" "$CONFIGURE_LOG" "./configure"
+    append_status "make" "skipped" "$MAKE_LOG" "make"
+fi
+
+summarize_warnings
+
+{
+    echo "# Finished at: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "# Final exit code: $final_rc"
+} >> "$STATUS_FILE"
+
+exit "$final_rc"

--- a/tools/baseline/compare_audio_outputs.py
+++ b/tools/baseline/compare_audio_outputs.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Compare DECtalk audio/file-output baseline capture directories."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import os
+from pathlib import Path
+import sys
+import wave
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare two capture_audio_outputs.sh output directories."
+    )
+    parser.add_argument(
+        "--baseline",
+        required=True,
+        help="Older capture directory containing an audio/ subdirectory.",
+    )
+    parser.add_argument(
+        "--candidate",
+        required=True,
+        help="Newer capture directory containing an audio/ subdirectory.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Markdown report path to write.",
+    )
+    return parser.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def audio_files(audio_dir: Path) -> dict[str, Path]:
+    return {
+        path.name: path
+        for path in sorted(audio_dir.iterdir())
+        if path.is_file()
+    }
+
+
+def wav_metadata(path: Path) -> tuple[dict[str, object] | None, str | None]:
+    if path.suffix.lower() != ".wav":
+        return None, None
+    try:
+        with wave.open(str(path), "rb") as handle:
+            channels = handle.getnchannels()
+            sample_width = handle.getsampwidth()
+            sample_rate = handle.getframerate()
+            frame_count = handle.getnframes()
+    except (EOFError, wave.Error, OSError) as exc:
+        return None, str(exc)
+
+    duration = None
+    if sample_rate:
+        duration = frame_count / float(sample_rate)
+
+    return {
+        "channels": channels,
+        "sample_width": sample_width,
+        "sample_rate": sample_rate,
+        "frame_count": frame_count,
+        "duration": duration,
+    }, None
+
+
+def format_duration(value: object) -> str:
+    if isinstance(value, float):
+        return f"{value:.6f}"
+    return str(value)
+
+
+def metadata_to_text(metadata: dict[str, object] | None) -> str:
+    if metadata is None:
+        return "-"
+    return (
+        f"rate={metadata['sample_rate']}, "
+        f"width={metadata['sample_width']}, "
+        f"channels={metadata['channels']}, "
+        f"frames={metadata['frame_count']}, "
+        f"duration={format_duration(metadata['duration'])}"
+    )
+
+
+def md(text: object) -> str:
+    value = str(text)
+    return value.replace("|", "\\|").replace("\n", " ")
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(Path.cwd()))
+    except ValueError:
+        return str(path)
+
+
+def write_section_list(lines: list[str], title: str, rows: list[str]) -> None:
+    lines.append(f"## {title}")
+    lines.append("")
+    if rows:
+        lines.extend(rows)
+    else:
+        lines.append("None.")
+    lines.append("")
+
+
+def compare(baseline_dir: Path, candidate_dir: Path) -> tuple[list[str], bool]:
+    baseline_audio = baseline_dir / "audio"
+    candidate_audio = candidate_dir / "audio"
+    errors: list[str] = []
+
+    if not baseline_audio.is_dir():
+        errors.append(f"Baseline audio directory is missing: `{baseline_audio}`")
+    if not candidate_audio.is_dir():
+        errors.append(f"Candidate audio directory is missing: `{candidate_audio}`")
+
+    if errors:
+        lines = report_header(baseline_dir, candidate_dir)
+        write_section_list(lines, "Layout Errors", [f"- {error}" for error in errors])
+        add_limitations(lines)
+        return lines, False
+
+    baseline_files = audio_files(baseline_audio)
+    candidate_files = audio_files(candidate_audio)
+
+    baseline_names = set(baseline_files)
+    candidate_names = set(candidate_files)
+    common_names = sorted(baseline_names & candidate_names)
+    missing_names = sorted(baseline_names - candidate_names)
+    extra_names = sorted(candidate_names - baseline_names)
+
+    exact_rows: list[dict[str, object]] = []
+    differing_rows: list[dict[str, object]] = []
+    wav_rows: list[dict[str, object]] = []
+    metadata_differences: list[dict[str, object]] = []
+    metadata_errors: list[dict[str, object]] = []
+    unreadable: list[str] = []
+
+    for name in common_names:
+        baseline_path = baseline_files[name]
+        candidate_path = candidate_files[name]
+        row: dict[str, object] = {"name": name}
+
+        try:
+            baseline_size = baseline_path.stat().st_size
+            baseline_hash = sha256_file(baseline_path)
+        except OSError as exc:
+            unreadable.append(f"`{name}` baseline unreadable: {exc}")
+            continue
+
+        try:
+            candidate_size = candidate_path.stat().st_size
+            candidate_hash = sha256_file(candidate_path)
+        except OSError as exc:
+            unreadable.append(f"`{name}` candidate unreadable: {exc}")
+            continue
+
+        row.update(
+            {
+                "baseline_size": baseline_size,
+                "candidate_size": candidate_size,
+                "baseline_hash": baseline_hash,
+                "candidate_hash": candidate_hash,
+                "size_match": baseline_size == candidate_size,
+                "hash_match": baseline_hash == candidate_hash,
+            }
+        )
+        exact_rows.append(row)
+        if not row["size_match"] or not row["hash_match"]:
+            differing_rows.append(row)
+
+        baseline_meta, baseline_meta_error = wav_metadata(baseline_path)
+        candidate_meta, candidate_meta_error = wav_metadata(candidate_path)
+        wav_row = {
+            "name": name,
+            "baseline_meta": baseline_meta,
+            "candidate_meta": candidate_meta,
+            "baseline_error": baseline_meta_error,
+            "candidate_error": candidate_meta_error,
+            "metadata_match": baseline_meta == candidate_meta
+            and baseline_meta_error == candidate_meta_error,
+        }
+        wav_rows.append(wav_row)
+
+        if baseline_meta_error or candidate_meta_error:
+            metadata_errors.append(wav_row)
+        elif baseline_meta != candidate_meta:
+            metadata_differences.append(wav_row)
+
+    matched_exactly = [
+        row
+        for row in exact_rows
+        if row["size_match"] and row["hash_match"]
+    ]
+    all_ok = (
+        not missing_names
+        and not extra_names
+        and not unreadable
+        and not differing_rows
+        and not metadata_errors
+        and not metadata_differences
+        and bool(common_names)
+    )
+
+    lines = report_header(baseline_dir, candidate_dir)
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Metric | Count |")
+    lines.append("| --- | ---: |")
+    lines.append(f"| Baseline artifacts | {len(baseline_names)} |")
+    lines.append(f"| Candidate artifacts | {len(candidate_names)} |")
+    lines.append(f"| Compared artifacts | {len(common_names)} |")
+    lines.append(f"| Exact matches | {len(matched_exactly)} |")
+    lines.append(f"| Missing files | {len(missing_names)} |")
+    lines.append(f"| Extra files | {len(extra_names)} |")
+    lines.append(f"| Differing files | {len(differing_rows)} |")
+    lines.append(f"| Unreadable files | {len(unreadable)} |")
+    lines.append(f"| WAV metadata differences | {len(metadata_differences)} |")
+    lines.append(f"| WAV metadata errors | {len(metadata_errors)} |")
+    lines.append("")
+    lines.append("## Exact Match Status")
+    lines.append("")
+    lines.append("PASS" if all_ok else "FAIL")
+    lines.append("")
+
+    write_section_list(
+        lines,
+        "Missing Files",
+        [f"- `{name}` is present in baseline but missing from candidate." for name in missing_names],
+    )
+    write_section_list(
+        lines,
+        "Extra Files",
+        [f"- `{name}` is present in candidate but missing from baseline." for name in extra_names],
+    )
+    write_section_list(lines, "Unreadable Files", [f"- {item}" for item in unreadable])
+
+    lines.append("## Differing Files")
+    lines.append("")
+    if differing_rows:
+        lines.append(
+            "| File | Baseline Size | Candidate Size | Baseline SHA-256 | Candidate SHA-256 |"
+        )
+        lines.append("| --- | ---: | ---: | --- | --- |")
+        for row in differing_rows:
+            lines.append(
+                "| {name} | {baseline_size} | {candidate_size} | `{baseline_hash}` | `{candidate_hash}` |".format(
+                    name=md(row["name"]),
+                    baseline_size=row["baseline_size"],
+                    candidate_size=row["candidate_size"],
+                    baseline_hash=row["baseline_hash"],
+                    candidate_hash=row["candidate_hash"],
+                )
+            )
+    else:
+        lines.append("None.")
+    lines.append("")
+
+    lines.append("## WAV Metadata Comparison")
+    lines.append("")
+    if wav_rows:
+        lines.append(
+            "| File | Metadata Match | Baseline Metadata | Candidate Metadata | Metadata Errors |"
+        )
+        lines.append("| --- | --- | --- | --- | --- |")
+        for row in wav_rows:
+            errors_text = []
+            if row["baseline_error"]:
+                errors_text.append(f"baseline: {row['baseline_error']}")
+            if row["candidate_error"]:
+                errors_text.append(f"candidate: {row['candidate_error']}")
+            lines.append(
+                "| {name} | {match} | {baseline} | {candidate} | {errors} |".format(
+                    name=md(row["name"]),
+                    match="yes" if row["metadata_match"] else "no",
+                    baseline=md(metadata_to_text(row["baseline_meta"])),
+                    candidate=md(metadata_to_text(row["candidate_meta"])),
+                    errors=md("; ".join(errors_text) if errors_text else "-"),
+                )
+            )
+    else:
+        lines.append("No common artifacts were available for WAV metadata comparison.")
+    lines.append("")
+
+    add_limitations(lines)
+    return lines, all_ok
+
+
+def report_header(baseline_dir: Path, candidate_dir: Path) -> list[str]:
+    timestamp = _dt.datetime.now(tz=_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return [
+        "# DECtalk Audio/File-Output Comparison",
+        "",
+        f"- Generated at: {timestamp}",
+        f"- Baseline directory: `{rel(baseline_dir)}`",
+        f"- Candidate directory: `{rel(candidate_dir)}`",
+        "",
+    ]
+
+
+def add_limitations(lines: list[str]) -> None:
+    lines.append("## Limitations")
+    lines.append("")
+    lines.append("- This report does not prove behavior preservation.")
+    lines.append("- Exact SHA-256 equality is strict and may be too strong across platforms.")
+    lines.append("- WAV metadata is parsed only with Python's standard `wave` module.")
+    lines.append("- Non-WAV artifacts are compared by size and SHA-256 only.")
+    lines.append("- No NumPy, SciPy, ffmpeg, perceptual analysis, or audio playback is used.")
+    lines.append("- No RMS, peak, or sample-delta comparison is performed.")
+    lines.append("")
+
+
+def main() -> int:
+    args = parse_args()
+    baseline_dir = Path(args.baseline)
+    candidate_dir = Path(args.candidate)
+    output_path = Path(args.output)
+
+    report_lines, ok = compare(baseline_dir, candidate_dir)
+
+    if output_path.parent != Path(""):
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(report_lines), encoding="utf-8")
+
+    if ok:
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/baseline/summarize_warnings.py
+++ b/tools/baseline/summarize_warnings.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Summarize compiler warning logs for baseline capture."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import datetime as _datetime
+from pathlib import Path
+import re
+import sys
+
+
+CATEGORIES = [
+    "missing prototype / implicit declaration",
+    "incompatible pointer type",
+    "pointer/integer conversion",
+    "integer conversion / truncation",
+    "signed/unsigned comparison",
+    "unused variable/function/parameter",
+    "format string mismatch",
+    "uninitialized variable",
+    "deprecated declaration/API",
+    "macro redefinition",
+    "unreachable/dead code",
+    "syntax/preprocessor",
+    "unknown compiler warning",
+    "uncategorized",
+]
+
+
+CATEGORY_PATTERNS = [
+    (
+        "missing prototype / implicit declaration",
+        [
+            r"\bimplicit declaration\b",
+            r"\bimplicitly declaring\b",
+            r"\bno previous prototype\b",
+            r"\bmissing prototype\b",
+            r"\bnot declared\b",
+            r"\bundeclared\b",
+            r"\bC4013\b",
+            r"\bC2065\b",
+        ],
+    ),
+    (
+        "incompatible pointer type",
+        [
+            r"\bincompatible pointer type",
+            r"\bincompatible pointer types",
+            r"\bpointer type mismatch\b",
+            r"\bC4133\b",
+            r"\bC4047\b",
+        ],
+    ),
+    (
+        "pointer/integer conversion",
+        [
+            r"\bcast (to|from) pointer from integer",
+            r"\bcast (to|from) integer from pointer",
+            r"\bpointer from integer",
+            r"\binteger from pointer",
+            r"\bmakes pointer from integer",
+            r"\bmakes integer from pointer",
+            r"\bpointer-to-int",
+            r"\bint-to-pointer",
+            r"\bC4311\b",
+            r"\bC4312\b",
+        ],
+    ),
+    (
+        "integer conversion / truncation",
+        [
+            r"\bconversion\b.*\bmay (alter|change|lose)\b",
+            r"\bconversion\b.*\bpossible loss of data\b",
+            r"\bconversion\b.*\btruncat",
+            r"\bshorten\b",
+            r"\boverflow\b",
+            r"\bconstant conversion\b",
+            r"\bC4244\b",
+            r"\bC4267\b",
+            r"\bC4305\b",
+            r"\bC4309\b",
+        ],
+    ),
+    (
+        "signed/unsigned comparison",
+        [
+            r"\bsigned and unsigned\b",
+            r"\bcomparison of integer expressions of different signedness\b",
+            r"\b-Wsign-compare\b",
+            r"\bC4018\b",
+        ],
+    ),
+    (
+        "unused variable/function/parameter",
+        [
+            r"\bunused (variable|function|parameter|argument|label|value)\b",
+            r"\bdefined but not used\b",
+            r"\bdeclared but never referenced\b",
+            r"\bunreferenced formal parameter\b",
+            r"\bunreferenced local variable\b",
+            r"\bset but not used\b",
+            r"\b-Wunused",
+            r"\bC4100\b",
+            r"\bC4101\b",
+            r"\bC4189\b",
+            r"\bC4505\b",
+        ],
+    ),
+    (
+        "format string mismatch",
+        [
+            r"\bformat\b.*\bexpects\b",
+            r"\bformat\b.*\bargument\b",
+            r"\bformat specifies type\b",
+            r"\btoo (many|few) arguments for format\b",
+            r"\b-Wformat",
+            r"\bC4473\b",
+            r"\bC4474\b",
+            r"\bC4477\b",
+        ],
+    ),
+    (
+        "uninitialized variable",
+        [
+            r"\buninitialized\b",
+            r"\bmay be used uninitialized\b",
+            r"\bused without having been initialized\b",
+            r"\bC4700\b",
+            r"\bC4701\b",
+            r"\bC4703\b",
+        ],
+    ),
+    (
+        "deprecated declaration/API",
+        [
+            r"\bdeprecated\b",
+            r"\bwas declared deprecated\b",
+            r"\bC4996\b",
+        ],
+    ),
+    (
+        "macro redefinition",
+        [
+            r"\bmacro redefined\b",
+            r"\bredefined\b.*\bmacro\b",
+            r"\b(re)?definition of macro\b",
+            r"\bC4005\b",
+        ],
+    ),
+    (
+        "unreachable/dead code",
+        [
+            r"\bunreachable code\b",
+            r"\bwill never be executed\b",
+            r"\bstatement is unreachable\b",
+            r"\bC4702\b",
+        ],
+    ),
+    (
+        "syntax/preprocessor",
+        [
+            r"\bextra tokens at end of #",
+            r"\bunterminated\b",
+            r"\bmissing .*#endif\b",
+            r"\b#pragma\b",
+            r"\bunknown pragma\b",
+            r"\b-Wcpp\b",
+            r"\bC4068\b",
+            r"\bC4067\b",
+        ],
+    ),
+]
+
+
+GCC_CLANG_WARNING_RE = re.compile(
+    r"^(?P<file>.*?):(?P<line>\d+)(?::(?P<column>\d+))?:\s+warning:\s+(?P<message>.*)$"
+)
+MSVC_WARNING_RE = re.compile(
+    r"^(?P<file>.*?)(?:\((?P<line>\d+)(?:,\d+)?\))?\s*:\s+warning\s+"
+    r"(?P<code>[A-Z]+\d+)\s*:\s*(?P<message>.*)$",
+    re.IGNORECASE,
+)
+GENERIC_WARNING_RE = re.compile(r"\bwarning\b", re.IGNORECASE)
+GCC_FLAG_RE = re.compile(r"\[-W[^\]]+\]")
+MSVC_CODE_RE = re.compile(r"\b(?:C|LNK)\d{4,5}\b", re.IGNORECASE)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Summarize compiler/build warning logs into Markdown."
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Markdown output file to write.",
+    )
+    parser.add_argument(
+        "--max-examples-per-category",
+        type=int,
+        default=10,
+        help="Maximum representative warning lines to keep per category.",
+    )
+    parser.add_argument(
+        "logs",
+        nargs="+",
+        help="Compiler or build log files to summarize.",
+    )
+    return parser.parse_args(argv)
+
+
+def normalize_warning_line(line: str) -> str | None:
+    stripped = line.rstrip("\n")
+    if GCC_CLANG_WARNING_RE.search(stripped):
+        return stripped
+    if MSVC_WARNING_RE.search(stripped):
+        return stripped
+    if GENERIC_WARNING_RE.search(stripped):
+        return stripped
+    return None
+
+
+def classify_warning(line: str) -> str:
+    lower = line.lower()
+    for category, patterns in CATEGORY_PATTERNS:
+        for pattern in patterns:
+            if re.search(pattern, lower, re.IGNORECASE):
+                return category
+    if GCC_CLANG_WARNING_RE.search(line) or MSVC_WARNING_RE.search(line):
+        return "unknown compiler warning"
+    return "uncategorized"
+
+
+def extract_markers(line: str) -> list[str]:
+    markers = []
+    markers.extend(GCC_FLAG_RE.findall(line))
+    markers.extend(match.upper() for match in MSVC_CODE_RE.findall(line))
+    return markers
+
+
+def read_warnings(log_paths: list[Path]) -> list[tuple[Path, int, str]]:
+    warnings = []
+    for log_path in log_paths:
+        if not log_path.exists():
+            raise FileNotFoundError(f"input log file does not exist: {log_path}")
+        if not log_path.is_file():
+            raise FileNotFoundError(f"input log path is not a file: {log_path}")
+        with log_path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line_number, line in enumerate(handle, start=1):
+                warning_line = normalize_warning_line(line)
+                if warning_line is not None:
+                    warnings.append((log_path, line_number, warning_line))
+    return warnings
+
+
+def markdown_escape_cell(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ")
+
+
+def write_markdown(
+    output_path: Path,
+    log_paths: list[Path],
+    warnings: list[tuple[Path, int, str]],
+    max_examples: int,
+) -> None:
+    counts = collections.Counter()
+    examples: dict[str, list[tuple[Path, int, str]]] = {category: [] for category in CATEGORIES}
+    markers: dict[str, collections.Counter[str]] = {
+        category: collections.Counter() for category in CATEGORIES
+    }
+
+    for log_path, line_number, line in warnings:
+        category = classify_warning(line)
+        counts[category] += 1
+        if len(examples[category]) < max_examples:
+            examples[category].append((log_path, line_number, line))
+        for marker in extract_markers(line):
+            markers[category][marker] += 1
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    generated_at = _datetime.datetime.now(_datetime.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+    with output_path.open("w", encoding="utf-8") as out:
+        out.write("# Warning Summary\n\n")
+        out.write(f"Generated at: `{generated_at}`\n\n")
+        out.write(
+            "This is a heuristic warning inventory for baseline capture. "
+            "It does not prove behavior preservation.\n\n"
+        )
+
+        out.write("## Input Logs\n\n")
+        for log_path in log_paths:
+            out.write(f"- `{log_path}`\n")
+        out.write("\n")
+
+        out.write("## Totals\n\n")
+        out.write(f"- Total warning-like lines: `{len(warnings)}`\n")
+        out.write(f"- Categorized warning-like lines: `{sum(counts.values())}`\n\n")
+
+        out.write("## Category Counts\n\n")
+        out.write("| Category | Count |\n")
+        out.write("| --- | ---: |\n")
+        for category in CATEGORIES:
+            out.write(f"| {markdown_escape_cell(category)} | {counts[category]} |\n")
+        out.write("\n")
+
+        out.write("## Categories\n\n")
+        for category in CATEGORIES:
+            count = counts[category]
+            if count == 0:
+                continue
+            out.write(f"### {category}\n\n")
+            out.write(f"Count: `{count}`\n\n")
+
+            if markers[category]:
+                out.write("Detected warning markers:\n\n")
+                for marker, marker_count in markers[category].most_common():
+                    out.write(f"- `{marker}`: `{marker_count}`\n")
+                out.write("\n")
+
+            out.write("Representative examples:\n\n")
+            for log_path, line_number, line in examples[category]:
+                out.write(f"- `{log_path}:{line_number}`\n\n")
+                out.write("  ```text\n")
+                out.write(f"  {line}\n")
+                out.write("  ```\n\n")
+
+        out.write("## Limitations\n\n")
+        out.write("- Warning categorization is heuristic and compiler messages vary.\n")
+        out.write("- Multi-line diagnostics are not reconstructed; only warning-like lines are summarized.\n")
+        out.write("- Some DECtalk-specific or tool-specific warnings may appear as `uncategorized`.\n")
+        out.write("- Counts are for warning-like lines, not necessarily unique compiler diagnostics.\n")
+        out.write("- This summary is for cleanup planning and baseline capture only.\n")
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.max_examples_per_category < 0:
+        print("error: --max-examples-per-category must be non-negative", file=sys.stderr)
+        return 2
+
+    log_paths = [Path(log) for log in args.logs]
+    output_path = Path(args.output)
+
+    try:
+        warnings = read_warnings(log_paths)
+        write_markdown(
+            output_path=output_path,
+            log_paths=log_paths,
+            warnings=warnings,
+            max_examples=args.max_examples_per_category,
+        )
+    except OSError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/baseline/summarize_warnings.py
+++ b/tools/baseline/summarize_warnings.py
@@ -20,6 +20,7 @@ CATEGORIES = [
     "unused variable/function/parameter",
     "format string mismatch",
     "uninitialized variable",
+    "unsafe temporary file API",
     "deprecated declaration/API",
     "macro redefinition",
     "unreachable/dead code",
@@ -30,6 +31,15 @@ CATEGORIES = [
 
 
 CATEGORY_PATTERNS = [
+    (
+        "unsafe temporary file API",
+        [
+            r"\btmpnam\b",
+            r"\bmktemp\b",
+            r"\btempnam\b",
+            r"\bmkstemp\b",
+        ],
+    ),
     (
         "missing prototype / implicit declaration",
         [


### PR DESCRIPTION
This PR focuses the next modernization phase on Linux first while explicitly deferring, not abandoning, Windows/macOS/iOS follow-up work.

Changes:
- Adds a Linux modernization plan
- Adds a Linux build graph document
- Documents the observed Linux build flow, major source directories, artifacts, and risk boundaries
- Establishes that CMake and build-system changes are not started yet

Not changed:
- No source files
- No build files
- No macros
- No generated artifacts
- No behavior changes

Notes:
- This is documentation-only planning for the next Linux-focused modernization phase.